### PR TITLE
Pause spec helper function and customisable wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Import `Tester`, `TestHookStore` and your specs in `index.ios.js` and/or
 Wrap your app in a Tester component, passing in the `testHookStore` and an array
 containing your spec functions.
 
+You may optionally pass in a value for `waitTime`, being an integer representing
+the time in milliseconds that your tests should wait to find specified 'hooked'
+components. By default, `waitTime` is set to two seconds.
+
 ```javascript
 import React, { Component } from 'react';
 import { AppRegistry } from 'react-native';
@@ -94,7 +98,7 @@ const testHookStore = new TestHookStore();
 export default class AppWrapper extends Component {
   render() {
     return (
-      <Tester specs={[AppSpec]} store={testHookStore}>
+      <Tester specs={[AppSpec]} store={testHookStore} waitTime={4000}>
         <App />
       </Tester>
     );

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -6,10 +6,11 @@ const DEFAULT_WAIT_TIME = 2000;
 // spec files.
 export default class TestScope {
 
-  constructor(component) {
+  constructor(component, waitTime) {
     this.component = component;
     this.testHooks = component.testHookStore;
     this.testCases = [];
+    this.waitTime = waitTime || DEFAULT_WAIT_TIME;
 
     this.run.bind(this);
   }
@@ -32,7 +33,7 @@ export default class TestScope {
   }
 
   // Public: Find a component by its test hook identifier. Waits
-  // `DEFAULT_WAIT_TIME` for the component to appear before abandoning.
+  // this.waitTime for the component to appear before abandoning.
   //
   // Usually, you'll want to use `exists` instead.
   //
@@ -47,7 +48,7 @@ export default class TestScope {
   //
   // Returns a promise; use `await` when calling this function. Resolves the
   // promise if the component is found, rejects the promise after
-  // `DEFAULT_WAIT_TIME` if the component is never found in the test hook
+  // this.waitTime if the component is never found in the test hook
   // store.
   findComponent(identifier) {
     let promise = new Promise((resolve, reject) => {
@@ -58,7 +59,7 @@ export default class TestScope {
           clearInterval(loop);
           return resolve(component);
         } else {
-          if (Date.now() - startTime >= DEFAULT_WAIT_TIME) {
+          if (Date.now() - startTime >= this.waitTime) {
             reject(new Error(`Could not find component with identifier ${identifier}`));
             clearInterval(loop);
           }

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -75,15 +75,15 @@ export default class TestScope {
   // f     - Callback function containing your tests cases defined with `it`.
   //
   // Example
-  //  
+  //
   //   // specs/MyFeatureSpec.js
   //   export default function(spec) {
   //     spec.describe('My Scene', function() {
-  //       
+  //
   //       spec.it('Has a component', async function() {
   //         await spec.exists('MyScene.myComponent');
   //       });
-  //  
+  //
   //     });
   //   }
   //
@@ -128,6 +128,22 @@ export default class TestScope {
   async press(identifier) {
     const component = await this.findComponent(identifier);
     component.props.onPress();
+  }
+
+  // Public: Pause the test for a specified length of time, perhaps to allow
+  // time for a request response to be received.
+  //
+  // time - Integer length of time to pause for (in milliseconds).
+  //
+  // Returns a promise, use await when calling this function.
+  async pause(time) {
+    let promise = new Promise((resolve, reject) => {
+      setTimeout(function() {
+        resolve();
+      }, time);
+    });
+
+    return promise;
   }
 
   // Public: Check a component exists.

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -1,5 +1,3 @@
-const DEFAULT_WAIT_TIME = 2000;
-
 // Internal: Wrapper around an app being tested, and a bunch of test cases.
 //
 // The TestScope also includes all the functions available when writing your
@@ -10,7 +8,7 @@ export default class TestScope {
     this.component = component;
     this.testHooks = component.testHookStore;
     this.testCases = [];
-    this.waitTime = waitTime || DEFAULT_WAIT_TIME;
+    this.waitTime = waitTime;
 
     this.run.bind(this);
   }

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -89,3 +89,7 @@ Tester.propTypes = {
 Tester.childContextTypes = {
   testHooks: PropTypes.instanceOf(TestHookStore)
 }
+
+Tester.defaultProps = {
+  waitTime: 2000
+}

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -13,8 +13,11 @@ import {
 // This component wraps your app inside a <View> to facilitate
 // re-rendering with a new key after each test case.
 //
-// store - An instance of TestHookStore.
-// specs - An array of spec functions.
+// store    - An instance of TestHookStore.
+// specs    - An array of spec functions.
+// waitTime - An integer representing the time in milliseconds that the testing
+//            framework should wait for the function findComponent() to return
+//            the 'hooked' component.
 //
 // Example
 //
@@ -56,7 +59,7 @@ export default class Tester extends Component {
   }
 
   async runTests() {
-    scope = new TestScope(this);
+    scope = new TestScope(this, this.props.waitTime);
     for (var i = 0; i < this.props.specs.length; i++) {
       await this.props.specs[i](scope);
     }
@@ -79,7 +82,8 @@ export default class Tester extends Component {
 
 Tester.propTypes = {
   store: PropTypes.instanceOf(TestHookStore),
-  specs: PropTypes.arrayOf(PropTypes.func)
+  specs: PropTypes.arrayOf(PropTypes.func),
+  waitTime: PropTypes.number
 };
 
 Tester.childContextTypes = {


### PR DESCRIPTION
This pull request contains two new pieces of functionality:

1. A new 'pause' spec helper in TestScope which allows you to pause the test script for a specified length of time. This is useful when awaiting request responses etc.

2. An optional waitTime can now be passed into Tester, which sets the milliseconds the function findComponent() waits to find a specified component before rejecting the promise. This value defaults to 2 secs if nothing is provided. 

