### PR TITLE
Clear AsyncStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,15 @@ Import `Tester`, `TestHookStore` and your specs in your top-level JS file
 Wrap your app in a Tester component, passing in the `TestHookStore` and an array
 containing your imported spec functions.
 
-You may optionally pass in a value for `waitTime`, being an integer representing
-the time in milliseconds that your tests should wait to find specified 'hooked'
-components. By default, `waitTime` is set to two seconds.
+Optional props:
+
+`waitTime`          - Integer, the time in milliseconds that your tests should
+                      wait to find specified 'hooked' components.
+                      Set to `2000` (2 seconds) by default.
+
+`clearAsyncStorage` - Boolean, set this to `true` to clear AsyncStorage between
+                      each test e.g. to remove a logged in user.
+                      Set to `false` by default.
 
 ```javascript
 import React, { Component } from 'react';

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -34,6 +34,7 @@ export default class TestScope {
       } catch (e) {
         console.warn(`${description}  ❎\n   ${e.message}`);
       }
+      await this.component.clearAsync();
       this.component.reRender();
     }
   }

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -1,6 +1,8 @@
-import React, { Component, Children, PropTypes } from 'react'
-import TestHookStore from './TestHookStore'
-import TestScope from './TestScope'
+import React, { Component, Children, PropTypes } from 'react';
+import { AsyncStorage } from 'react-native';
+
+import TestHookStore from './TestHookStore';
+import TestScope from './TestScope';
 
 import {
   View
@@ -13,11 +15,13 @@ import {
 // This component wraps your app inside a <View> to facilitate
 // re-rendering with a new key after each test case.
 //
-// store    - An instance of TestHookStore.
-// specs    - An array of spec functions.
-// waitTime - An integer representing the time in milliseconds that the testing
-//            framework should wait for the function findComponent() to return
-//            the 'hooked' component.
+// store             - An instance of TestHookStore.
+// specs             - An array of spec functions.
+// waitTime          - An integer representing the time in milliseconds that
+//                     the testing framework should wait for the function
+//                     findComponent() to return the 'hooked' component.
+// clearAsyncStorage - A boolean to determine whether to clear AsyncStorage
+//                     between each test. Defaults to `false`.
 //
 // Example
 //
@@ -70,6 +74,10 @@ export default class Tester extends Component {
     this.setState({key: Math.random()});
   }
 
+  clearAsync() {
+    if (this.props.clearAsyncStorage) { AsyncStorage.clear(); }
+  }
+
   render() {
     return (
       <View key={this.state.key} style={{flex: 1}}>
@@ -83,7 +91,8 @@ export default class Tester extends Component {
 Tester.propTypes = {
   store: PropTypes.instanceOf(TestHookStore),
   specs: PropTypes.arrayOf(PropTypes.func),
-  waitTime: PropTypes.number
+  waitTime: PropTypes.number,
+  clearAsync: PropTypes.bool
 };
 
 Tester.childContextTypes = {
@@ -91,5 +100,6 @@ Tester.childContextTypes = {
 }
 
 Tester.defaultProps = {
-  waitTime: 2000
+  waitTime: 2000,
+  clearAsyncStorage: false
 }

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -74,8 +74,8 @@ export default class Tester extends Component {
     this.setState({key: Math.random()});
   }
 
-  clearAsync() {
-    if (this.props.clearAsyncStorage) { AsyncStorage.clear(); }
+  async clearAsync() {
+    if (this.props.clearAsyncStorage) { await AsyncStorage.clear(); }
   }
 
   render() {

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -75,7 +75,13 @@ export default class Tester extends Component {
   }
 
   async clearAsync() {
-    if (this.props.clearAsyncStorage) { await AsyncStorage.clear(); }
+    if (this.props.clearAsyncStorage) { 
+      try {
+        await AsyncStorage.clear();
+      } catch(e) {
+        console.warn("[Cavy] failed to clear AsyncStorage:", e);
+      }
+    }
   }
 
   render() {

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -92,7 +92,7 @@ Tester.propTypes = {
   store: PropTypes.instanceOf(TestHookStore),
   specs: PropTypes.arrayOf(PropTypes.func),
   waitTime: PropTypes.number,
-  clearAsync: PropTypes.bool
+  clearAsyncStorage: PropTypes.bool
 };
 
 Tester.childContextTypes = {


### PR DESCRIPTION
Adds an optional prop to the Tester component `clearAsyncStorage`.
If set to `true`, AsyncStorage is cleared at the end of every test, before the app is re-rendered.
Set to `false` by default.