### PR TITLE
Add test suites & improve console.log reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/pixielabs/cavy/issues"
   },
-  "homepage": "https://github.com/pixielabs/cavy#readme"
+  "homepage": "https://github.com/pixielabs/cavy#readme",
+  "devDependencies": {
+    "lodash": "^4.17.4"
+  }
 }

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -1,3 +1,5 @@
+import {has, omit} from 'lodash';
+
 // Internal: Wrapper around an app being tested, and a bunch of test cases.
 //
 // The TestScope also includes all the functions available when writing your
@@ -8,15 +10,18 @@ class ComponentNotFoundError extends Error {
     super(message);
     this.name = 'ComponentNotFoundError';
   }
-};
+}
 
 export default class TestScope {
 
-  constructor(component, waitTime) {
+  constructor(component, testOptions) {
     this.component = component;
     this.testHooks = component.testHookStore;
-    this.testCases = [];
-    this.waitTime = waitTime;
+    this.testSuites = {};
+
+    this.waitTime = testOptions.waitTime;
+    this.testStartDelay = testOptions.testStartDelay;
+    this.consoleLog = testOptions.consoleLog;
 
     this.run.bind(this);
   }
@@ -26,17 +31,153 @@ export default class TestScope {
   // after each test case by changing the component key to force React to
   // re-render the entire component tree.
   async run() {
-    for (let i = 0; i < this.testCases.length; i++) {
-      let {description, f} = this.testCases[i];
-      try {
-        await f.call(this);
-        console.log(`${description}  ✅`);
-      } catch (e) {
-        console.warn(`${description}  ❌\n   ${e.message}`);
+
+    let start = new Date();
+    this._handleConsoleLog('Cavy tests started at ' + start);
+
+    if (this.testStartDelay) {
+      this.pause(this.testStartDelay);
+    }
+
+    let suiteKeys = Object.keys(this.testSuites);
+    for (let testSuiteIdx in suiteKeys) {
+      let testSuite = this.testSuites[suiteKeys[testSuiteIdx]];
+      let suiteStats = {};
+
+      suiteStats.start = new Date();
+      this._handleConsoleLog(suiteKeys[testSuiteIdx] + ' suite started at ' + suiteStats.start);
+
+      let caseKeys = Object.keys(testSuite);
+      for (let testCaseIdx in caseKeys) {
+        let testCase = testSuite[caseKeys[testCaseIdx]];
+        let caseStats = {};
+        let caseResult = {};
+
+        let {expected, f} = testCase;
+        let description = caseKeys[testCaseIdx];
+
+        try {
+          caseStats.start = new Date();
+          await f.call(this);
+          caseStats.finish = new Date();
+          
+          let actual = 'PASS';
+
+          if (expected === actual) {
+            this._handleConsoleLog(this._handlePass(description, expected, actual));
+            
+            caseResult = {
+              expected: expected,
+              actual: actual
+            };
+          } else {
+            let error = 'Expected result not equivalent to actual result.';
+            this._handleConsoleLog(this._handleFail(description, expected, actual, error), false, true);
+
+            caseResult = {
+              expected: expected,
+              actual: actual,
+              error: error
+            };
+          }
+          
+        } catch (e) {
+          caseStats.finish = new Date();
+
+          let actual = 'FAIL';
+
+          if (expected === actual) {
+            this._handleConsoleLog(this._handlePass(description, expected, actual));
+            caseResult = {
+              expected: expected,
+              actual: actual
+            };
+          } else {
+            this._handleConsoleLog(this._handleFail(description, expected, actual, e.message), false, true);
+            caseResult = {
+              expected: expected,
+              actual: actual,
+              error: e.message
+            };
+          }
+        }
+
+        caseStats.duration = (caseStats.finish - caseStats.start)/1000;
+
+        let noF = omit(testCase, 'f');
+        testSuite[caseKeys[testCaseIdx]] = {...noF, ...caseStats, ...caseResult};
+
+        this._handleConsoleLog({description, caseStats}, true);
       }
+
+      suiteStats.stop = new Date();
+      suiteStats.duration = (suiteStats.stop - suiteStats.start)/1000;
+
       await this.component.clearAsync();
       this.component.reRender();
+
+      this._handleConsoleLog('Suite stopped at ' + suiteStats.stop);
+      this._handleConsoleLog({suiteStats}, true);
     }
+
+    let finish = new Date();
+
+    this._handleConsoleLog('Cavy tests finished at ' + finish);
+    this._handleConsoleLog(this.testSuites);
+  }
+
+  // Internal: Handle reporting to console based on consoleLog prop
+  //
+  // log     - String, log to send to console
+  // verbose - Conditional [boolean, sring], controls report output.
+  //              false - no logging
+  //              true - logging
+  //              verbose - log all
+  // warn    - Use console.warn instead of console.log
+  _handleConsoleLog(log, verbose=false, warn=false) {
+    if (this.consoleLog) {
+      if (verbose) {
+        switch (this.consoleLog) {
+        case 'verbose':
+          if (warn) {
+            console.warn(log);
+          } else {
+            console.log(log);
+          }
+          break;
+        default:
+          break;
+        }
+      } else {
+        switch (warn) {
+        case true:
+          console.warn(log);
+          break;
+        case false:
+          console.log(log);
+          break;
+        }
+      }
+    }
+  }
+
+  // Internal: Handle pass test case logging string generation
+  //
+  // log       - String, test spec description
+  // expected  - String, expected test result, one of 'PASS', 'FAIL'
+  // actual    - String, actual test result, one of 'PASS', 'FAIL'
+  _handlePass(description, expected, actual) {
+    return `${description}  ✅\n    Expected: ${expected}\n    Actual: ${actual}`
+  }
+
+  // Internal: Handle pass test case logging string generation
+  //
+  // log       - String, test spec description
+  // expected  - String, expected test result, one of 'PASS', 'FAIL'
+  // actual    - String, actual test result, one of 'PASS', 'FAIL'
+  // error     - String, error message
+  _handleFail(description, expected, actual, error) {
+    return `${description}  ❌\n    Expected: ${expected}\n    Actual: ${actual}\n    Error: ${error}`
   }
 
   // Public: Find a component by its test hook identifier. Waits
@@ -77,10 +218,23 @@ export default class TestScope {
     return promise;
   }
 
-  // Public: Build up a group of test cases.
+  // Public: Build a test suite from N test cases.
   //
-  // label - Label for these test cases.
-  // f     - Callback function containing your tests cases defined with `it`.
+  // label - Label for the test suite.
+  // f     - Callback function containing your test specs defined with `describe`.
+  suite(label, f) {
+    if (!has(this.testSuites, label)) {
+      this.testSuites[label] = {};
+    }
+    this.activeSuiteKey = label;
+
+    f.call(this);
+  }
+
+  // Public: Build up a test case from a group of test specs.
+  //
+  // label - Label for this test case.
+  // f     - Callback function containing your test specs defined with `it`.
   //
   // Example
   //
@@ -101,16 +255,16 @@ export default class TestScope {
     f.call(this);
   }
 
-  // Public: Define a test case.
+  // Public: Define expected result from test spec. Adds the test description as a key
+  //         to the testSuite, with an object containing the expected result and callback as 
+  //         values.
   //
-  // label - Label for this test case. This is combined with the label from
-  //         `describe` when Cavy outputs to the console.
-  // f     - The test case.
+  // expected - Expected result from the test.
+  // f        - The test case.
   //
   // See example above.
-  it(label, f) {
-    const description = `${this.describeLabel}: ${label}`;
-    this.testCases.push({description, f});
+  it(expected, f) {
+    this.testSuites[this.activeSuiteKey][this.describeLabel] = {expected, f};
   }
 
   // Public: Fill in a `TextInput`-compatible component with a string value.


### PR DESCRIPTION
This PR refactors TestScope.js to add test specs to suites, improves console.log reporting, and updates props in Tester.js.

The biggest changes come to the run() method in TestScope.js.

# run() / TestScope.js

* Add test battery start / stop timestamp
* Add optional testStartDelay
* Loop through testSuites
    * Log suite start/stop timestamp
    * Loop through testCase
        * Log case start/stop timestamp
        * Optional: report result to console.log/warn
        * remove f from test case to simplify reporting
        * Save test case results to class object
* On completion of all test suites
    * Optional: Output test results to console.log

# Motivation for using Test Suites

I found a need for suites when architecting integration tests with Cavy. I see specs as small functions representing specific actions you compile into test cases, and may re-use multiple times. Test suites are collections of test cases and/or test specs that allow you to re-use lowest level testing functionality as needed.

For example, my spec definition file used at work contains five categories of specs (secret hooks, navigation, input, press, and presence). These all define basic interactions with the app, like navigating to a signup page, inputting text in a form, or ensuring that an error message doesn't show after an input action. 

Sometimes you need to chain multiple specs together into a test case for proper functionality. In this case, I'll define a test case which is a group of test specs. See case 2 in the example below.

I'll use two examples of our test suites to explain further. We test a variety of error and success conditions in our app as part of integration testing. One basic thing to test is user signup success and failure.

## test suite 1: emailSignupError
* spec 1: navSignupEmailSignup
* case 2: inputEmailSignupSubmit(spec, email, username, password)
           - presenceEmailSignupForm
           - inputEmailSignupForm(spec, email)
           - presenceUsernameSignupForm
           - inputUsernameSignupForm(spec, username)
           - presencePasswordSignupForm
           - inputPasswordSignupForm(spec, password)
           - presenceSignupContinue
           - pressSignupContinue
* spec 3: presenceEmailSignupError
* spec 4: navEmailSignupSignup

## test suite 2: emailSignupSuccess
* spec 1: navSignupEmailSignup
* case 2: inputEmailSignupSubmit(spec, email2, username2, password2)
* spec 3: notPresenceEmailSignupError
* spec 4: navEmailSignupInbox

By separating lower level actions from compiled suites, we are able to re-use specs throughout app tests. Making the inputEmailSignupSubmit spec take in parameters that define the email, username, and password allow us to re-use the spec function to address different test conditions we are exploring. Then we take the parameterized function and use it in two different suites with different expected outcomes.