### PR TITLE
Copying static properties from WrappedComponent

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -74,5 +74,10 @@ export default function hook(WrappedComponent) {
     testHooks: PropTypes.instanceOf(TestHookStore)
   }
 
+  // Copying static properties
+  Object.getOwnPropertyNames(WrappedComponent)
+    .filter(prop => typeof WrappedComponent[prop] === "function")
+    .forEach(sProp => (wrapperComponent[sProp] = WrappedComponent[sProp]));
+
   return wrapperComponent;
 }


### PR DESCRIPTION
I use the react navigation, that requires the static property navigationOptions, how about copying all static properties to the wrapperComponent? Then we could just use `@hook` decorator instead of declare navigationOptions after wrapping, like this:

```
@hook
class MyComponent extends Component {
 static navigationOptions = {...}
}
```

instead of

```
class MyComponent extends Component {
}

const hookedComponent = hook(MyComponent)

hookedComponent.navigationOptions = {...}
```