### PR TITLE
Updates generateTestHook() to check if testHooks are available...

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -56,6 +56,10 @@ export default function hook(WrappedComponent) {
     // React.
     generateTestHook(identifier, f = () => {}) {
       return (component) => {
+        if (!this.context.testHooks) {
+          f(component)
+          return
+        }
         if (component) {
           this.context.testHooks.add(identifier, component);
         } else {


### PR DESCRIPTION
…before attempting actions on them (calls f(component) and returns)

This means that if the user is testing their application with Jest and react-test-renderer, Cavy will not cause their test suites to fail.

Closes #42 