### PR TITLE
Import PropTypes and createReactClass from their packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
   "bugs": {
     "url": "https://github.com/pixielabs/cavy/issues"
   },
-  "homepage": "https://github.com/pixielabs/cavy#readme"
+  "homepage": "https://github.com/pixielabs/cavy#readme",
+  "dependencies": {
+    "prop-types": "^15.5.10",
+    "create-react-class": "^15.6.0"
+  }
 }

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -1,4 +1,5 @@
-import React, { Component, Children, PropTypes } from 'react';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types'
 import { AsyncStorage } from 'react-native';
 
 import TestHookStore from './TestHookStore';

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import TestHookStore from './TestHookStore';
 

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,4 +1,5 @@
-import React, { createClass } from 'react';
+import React from 'react';
+import createReactClass from 'create-react-class';
 
 // Public: Wrap a stateless (purely functional) component in a non-stateless
 // component so that a `ref` can be added.
@@ -42,5 +43,5 @@ export default function wrap(statelessComponent) {
     return statelessComponent(this.props, this.context);
   };
 
-  return createClass(reactClass);
+  return createReactClass(reactClass);
 }


### PR DESCRIPTION
This PR fixes https://github.com/pixielabs/cavy/issues/45 so that this package can work with latest react native versions.

I've done the migration based on > https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

Please have a review and let me know if there is anything else I need to do.

Cheers.