### PR TITLE
Add cavy-cli support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,69 +1,5 @@
 version: 2
 jobs:
-  android:
-    docker:
-      - image: circleci/android:api-23-node8-alpha
-
-    environment:
-      # https://circleci.com/docs/1.0/oom/
-      JVM_OPTS: -Xmx2048m
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-
-    steps:
-      - checkout
-
-      # Inspired by
-      # <https://github.com/flyve-mdm/android-mdm-agent/blob/develop/.circleci/config.yml>
-      - run:
-          name: Setup emulator
-          command: |
-            sdkmanager "system-images;android-23;google_apis;armeabi-v7a"
-            sdkmanager "build-tools;23.0.1"
-            echo "no" | avdmanager create avd -n test -k "system-images;android-23;google_apis;armeabi-v7a"
-
-      - run:
-          name: Launch emulator
-          command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator64-arm -avd test -noaudio -no-boot-anim -no-window -accel on
-          background: true
-      - run:
-          name: Wait for emulator to boot
-          command: |
-            # wait for it to have booted
-            circle-android wait-for-boot
-            # unlock the emulator screen
-            sleep 30
-            adb shell input keyevent 82
-
-      - run:
-          name: Install Node dependencies
-          command: npm i
-
-      - run:
-          name: Link local copy of cavy
-          command: sudo npm link
-
-      - run:
-          name: Install command line interfaces
-          command: sudo npm install -g cavy-cli react-native-cli
-
-      - run:
-          name: Install sample app dependencies
-          command: |
-            mv sample-app ~/
-            cd ~/sample-app/EmployeeDirectory
-            npm i
-            npm link cavy
-            cp rn-cli.config.js.example rn-cli.config.js
-
-      - run:
-          name: Build app and run tests
-          environment:
-            # Fix for '$TERM not set' error
-            TERM: dumb
-          command: |
-            cd ~/sample-app/EmployeeDirectory
-            cavy run-android
-
   ios:
 
     # Specify the Xcode version to use
@@ -106,7 +42,6 @@ jobs:
 
 workflows:
   version: 2
-  android-ios:
+  ios:
     jobs:
-      - android
       - ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,62 @@
 version: 2
 jobs:
-  build:
+  android:
+    docker:
+      - image: circleci/android:api-23-node8-alpha
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Inspired by
+      # <https://github.com/flyve-mdm/android-mdm-agent/blob/develop/.circleci/config.yml>
+      - run:
+          name: Setup emulator
+          command: sdkmanager "system-images;android-23;google_apis;armeabi-v7a" && echo "no" | avdmanager create avd -n test -k "system-images;android-23;google_apis;armeabi-v7a"
+
+      - run:
+          name: Launch emulator
+          command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator64-arm -avd test -noaudio -no-boot-anim -no-window -accel on
+          background: true
+      - run:
+          name: Wait for emulator to boot
+          command: |
+            # wait for it to have booted
+            circle-android wait-for-boot
+            # unlock the emulator screen
+            sleep 30
+            adb shell input keyevent 82
+
+      - run:
+          name: Install Node dependencies
+          command: npm i
+
+      - run:
+          name: Link local copy of cavy
+          command: npm link
+
+      - run:
+          name: Install command line interfaces
+          command: npm install -g cavy-cli react-native-cli
+
+      - run:
+          name: Install sample app dependencies
+          command: |
+            mv sample-app ~/
+            cd ~/sample-app/EmployeeDirectory
+            npm i
+            npm link cavy
+            cp rn-cli.config.js.example rn-cli.config.js
+
+      - run:
+          name: Build app and run tests
+          command: |
+            cd ~/sample-app/EmployeeDirectory
+            cavy run-android
+
+  ios:
 
     # Specify the Xcode version to use
     macos:
@@ -39,3 +95,10 @@ jobs:
           command: |
             cd ~/sample-app/EmployeeDirectory
             cavy run-ios
+
+workflows:
+  version: 2
+  android-ios:
+    jobs:
+      - android
+      - ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
       # <https://github.com/flyve-mdm/android-mdm-agent/blob/develop/.circleci/config.yml>
       - run:
           name: Setup emulator
-          command: sdkmanager "system-images;android-23;google_apis;armeabi-v7a" && echo "no" | avdmanager create avd -n test -k "system-images;android-23;google_apis;armeabi-v7a"
+          command: |
+            sdkmanager "system-images;android-23;google_apis;armeabi-v7a"
+            sdkmanager "build-tools;23.0.1"
+            echo "no" | avdmanager create avd -n test -k "system-images;android-23;google_apis;armeabi-v7a"
 
       - run:
           name: Launch emulator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
 
       - run:
           name: Build app and run tests
+          environment:
+            # Fix for '$TERM not set' error
+            TERM: dumb
           command: |
             cd ~/sample-app/EmployeeDirectory
             cavy run-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2
+jobs:
+  build:
+
+    # Specify the Xcode version to use
+    macos:
+      xcode: "9.0"
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install React Native dependencies
+          command: brew install watchman
+
+      - run:
+          name: Install Node dependencies
+          command: npm i
+
+      - run:
+          name: Link local copy of cavy
+          command: npm link
+
+      - run:
+          name: Install command line interfaces
+          command: npm install -g cavy-cli react-native-cli
+
+      - run:
+          name: Install sample app dependencies
+          command: |
+            mv sample-app ~/
+            cd ~/sample-app/EmployeeDirectory
+            npm i
+            npm link cavy
+            cp rn-cli.config.js.example rn-cli.config.js
+
+      - run:
+          name: Build app and run tests
+          command: |
+            cd ~/sample-app/EmployeeDirectory
+            cavy run-ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       - image: circleci/android:api-23-node8-alpha
 
     environment:
-      JVM_OPTS: -Xmx3200m
+      # https://circleci.com/docs/1.0/oom/
+      JVM_OPTS: -Xmx2048m
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ jobs:
 
       - run:
           name: Link local copy of cavy
-          command: npm link
+          command: sudo npm link
 
       - run:
           name: Install command line interfaces
-          command: npm install -g cavy-cli react-native-cli
+          command: sudo npm install -g cavy-cli react-native-cli
 
       - run:
           name: Install sample app dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.5.0
+
+- Support [cavy-cli](https://github.com/pixielabs/cavy-cli).
+
+cavy-cli is the next step in Cavy's development. With it, we can start to
+support Continuous Integration, conditionally running tests, and a bunch of
+other cool stuff. Thanks to [Tyler Pate](https://github.com/TGPSKI) whose
+suggestions inspired our approach.
+
 # 0.4.1
 
 - Stop using deprecated `PropTypes` and `createClass`. Thanks

--- a/README.md
+++ b/README.md
@@ -171,9 +171,8 @@ Optional props:
                       each test e.g. to remove a logged in user.
                       Set to `false` by default.
 
-`sendReport`        - Boolean, set this to `true` to have Cavy try and 
-                      send a report to [cavy-cli][cli]. Set to `false` by
-                      default.
+`sendReport`        - Boolean, set this to `true` to have Cavy send a report to
+                      [cavy-cli][cli]. Set to `false` by default.
 
 ```javascript
 import React, { Component } from 'react';

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 **Cavy** is a cross-platform integration test framework for React Native, by
 [Pixie Labs](http://pixielabs.io).
 
+This README covers installing and setting up Cavy, writing Cavy tests and FAQs.
+For information on how to use Cavy's **command line interface**, check out [cavy-cli](https://github.com/pixielabs/cavy-cli).
+
 ## Table of Contents
 - [How does it work?](#how-does-it-work)
   - [Where does it fit in?](#where-does-it-fit-in)
@@ -31,6 +34,9 @@ is running on a host device (e.g. your Android or iOS simulator).
 
 This allows you to do far more accurate integration testing than if you run
 your React app within a simulated rendering environment.
+
+### Continuous integration
+By default, Cavy outputs test results to the console when your app runs. However, you can also run Cavy tests directly from the command line using Cavy's own command line interface - [cavy-cli](https://github.com/pixielabs/cavy-cli). Details on how you can use cavy-cli to fully automate your tests with Continuous Integration can be found [here](https://github.com/pixielabs/cavy-cli).
 
 ### Where does it fit in?
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ is running on a host device (e.g. your Android or iOS simulator).
 This allows you to do far more accurate integration testing than if you run
 your React app within a simulated rendering environment.
 
-### Continuous integration
+### CLI and continuous integration
+
 By default, Cavy outputs test results to the console when your app runs.
 However, you can also run Cavy tests directly from the command line using
-Cavy's own command line interface -
-[cavy-cli][cli]. Details on how you can use
-cavy-cli to fully automate your tests with Continuous Integration can be found
-[in the cavy-cli README][cli].
+Cavy's own command line interface - [cavy-cli][cli]. Just set the `sendReport`
+prop on your `<Tester>` component to `true` (see below).
+
+Further details on how you can use cavy-cli to fully automate your tests with
+continuous integration can be found [in the cavy-cli README][cli].
 
 ### Where does it fit in?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cavy
 
 [![npm version](https://badge.fury.io/js/cavy.svg)](https://badge.fury.io/js/cavy)
+[![CircleCI](https://circleci.com/gh/pixielabs/cavy.svg?style=svg)](https://circleci.com/gh/pixielabs/cavy)
 
 ![Cavy logo](https://cloud.githubusercontent.com/assets/126989/22546798/6cf18938-e936-11e6-933f-da756b9ee7b8.png)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This README covers installing and setting up Cavy, writing Cavy tests and FAQs.
 For information on how to use Cavy's **command line interface**, check out
-[cavy-cli][].
+[cavy-cli][cli].
 
 ## Table of Contents
 - [How does it work?](#how-does-it-work)
@@ -41,9 +41,9 @@ your React app within a simulated rendering environment.
 By default, Cavy outputs test results to the console when your app runs.
 However, you can also run Cavy tests directly from the command line using
 Cavy's own command line interface -
-[cavy-cli][]. Details on how you can use
+[cavy-cli][cli]. Details on how you can use
 cavy-cli to fully automate your tests with Continuous Integration can be found
-[in the cavy-cli README][cavy-cli].
+[in the cavy-cli README][cli].
 
 ### Where does it fit in?
 
@@ -170,7 +170,7 @@ Optional props:
                       Set to `false` by default.
 
 `sendReport`        - Boolean, set this to `true` to have Cavy try and 
-                      send a report to [cavy-cli][]. Set to `false` by
+                      send a report to [cavy-cli][cli]. Set to `false` by
                       default.
 
 ```javascript
@@ -273,4 +273,4 @@ Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
   please isolate to its own commit so we can cherry-pick around it.
 
 [crna]: https://github.com/react-community/create-react-native-app
-[cavy-cli]: https://github.com/pixielabs/cavy-cli
+[cli]: https://github.com/pixielabs/cavy-cli

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [Pixie Labs](http://pixielabs.io).
 
 This README covers installing and setting up Cavy, writing Cavy tests and FAQs.
-For information on how to use Cavy's **command line interface**, check out [cavy-cli][]
+For information on how to use Cavy's **command line interface**, check out
+[cavy-cli][].
 
 ## Table of Contents
 - [How does it work?](#how-does-it-work)
@@ -272,4 +273,4 @@ Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
   please isolate to its own commit so we can cherry-pick around it.
 
 [crna]: https://github.com/react-community/create-react-native-app
-[cavy-cli] https://github.com/pixielabs/cavy-cli
+[cavy-cli]: https://github.com/pixielabs/cavy-cli

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [Pixie Labs](http://pixielabs.io).
 
 This README covers installing and setting up Cavy, writing Cavy tests and FAQs.
-For information on how to use Cavy's **command line interface**, check out [cavy-cli](https://github.com/pixielabs/cavy-cli).
+For information on how to use Cavy's **command line interface**, check out [cavy-cli][]
 
 ## Table of Contents
 - [How does it work?](#how-does-it-work)
@@ -37,7 +37,12 @@ This allows you to do far more accurate integration testing than if you run
 your React app within a simulated rendering environment.
 
 ### Continuous integration
-By default, Cavy outputs test results to the console when your app runs. However, you can also run Cavy tests directly from the command line using Cavy's own command line interface - [cavy-cli](https://github.com/pixielabs/cavy-cli). Details on how you can use cavy-cli to fully automate your tests with Continuous Integration can be found [here](https://github.com/pixielabs/cavy-cli).
+By default, Cavy outputs test results to the console when your app runs.
+However, you can also run Cavy tests directly from the command line using
+Cavy's own command line interface -
+[cavy-cli][]. Details on how you can use
+cavy-cli to fully automate your tests with Continuous Integration can be found
+[in the cavy-cli README][cavy-cli].
 
 ### Where does it fit in?
 
@@ -74,7 +79,8 @@ or `npm`:
 
 ## Basic usage
 
-Check out [the sample app](https://github.com/pixielabs/cavy/tree/master/sample-app/EmployeeDirectory) for example usage. Here it is running:
+Check out [the sample app](https://github.com/pixielabs/cavy/tree/master/sample-app/EmployeeDirectory)
+for example usage. Here it is running:
 
 ![Sample app running](https://cloud.githubusercontent.com/assets/126989/22829358/193b5c0a-ef9a-11e6-994e-d4df852a6181.gif)
 
@@ -83,12 +89,13 @@ Check out [the sample app](https://github.com/pixielabs/cavy/tree/master/sample-
 Add 'hooks' to any components you want to test by adding a `ref` and using the
 `generateTestHook` function.
 
-`generateTestHook` takes a string as its first argument - this is the identifier
-to be used in tests. It takes an optional second argument in case you want to
-set your own `ref` generating function.
+`generateTestHook` takes a string as its first argument - this is the
+identifier to be used in tests. It takes an optional second argument in case
+you want to set your own `ref` generating function.
 
-Stateless functional components cannot be assigned a `ref` since they don't have
-instances. Use the `wrap` function to wrap them inside a non-stateless component.
+Stateless functional components cannot be assigned a `ref` since they don't
+have instances. Use the `wrap` function to wrap them inside a non-stateless
+component.
 
 ```javascript
 import React, { Component } from 'react';
@@ -145,8 +152,8 @@ Import `Tester`, `TestHookStore` and your specs in your top-level JS file
 (typically this is your `index.{ios,android}.js` files), and instantiate a new
 `TestHookStore`.
 
-Wrap your app in a Tester component, passing in the `TestHookStore` and an array
-containing your imported spec functions.
+Wrap your app in a Tester component, passing in the `TestHookStore` and an
+array containing your imported spec functions.
 
 Optional props:
 
@@ -160,6 +167,10 @@ Optional props:
 `clearAsyncStorage` - Boolean, set this to `true` to clear AsyncStorage between
                       each test e.g. to remove a logged in user.
                       Set to `false` by default.
+
+`sendReport`        - Boolean, set this to `true` to have Cavy try and 
+                      send a report to [cavy-cli][]. Set to `false` by
+                      default.
 
 ```javascript
 import React, { Component } from 'react';
@@ -261,3 +272,4 @@ Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
   please isolate to its own commit so we can cherry-pick around it.
 
 [crna]: https://github.com/react-community/create-react-native-app
+[cavy-cli] https://github.com/pixielabs/cavy-cli

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "specs"
   ],
   "peerDependencies": {
-    "react-native": ">= 0.40.0 < 0.53"
+    "react-native": ">= 0.40.0 <= 0.53"
   },
   "author": "Pixie Labs",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavy",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "An integration test framework for React Native.",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "specs"
   ],
   "peerDependencies": {
-    "react-native": "0.40.x"
+    "react-native": ">= 0.40.0 < 0.53"
   },
   "author": "Pixie Labs",
   "license": "MIT",

--- a/sample-app/EmployeeDirectory/index.ios.js
+++ b/sample-app/EmployeeDirectory/index.ios.js
@@ -12,7 +12,8 @@ const testHookStore = new TestHookStore();
 class AppWrapper extends Component {
   render() {
     return (
-      <Tester specs={[EmployeeListSpec]} store={testHookStore} waitTime={1000} startDelay={3000}>
+      <Tester specs={[EmployeeListSpec]} store={testHookStore} waitTime={1000}
+        startDelay={3000} sendReport={true}>
         <EmployeeDirectoryApp />
       </Tester>
     );

--- a/sample-app/EmployeeDirectory/rn-cli.config.js.example
+++ b/sample-app/EmployeeDirectory/rn-cli.config.js.example
@@ -1,0 +1,21 @@
+// This configuration is to support a test build of the EmployeeDirectory app,
+// where you want to test a local version of cavy (in the parent directory)
+// instead of the published one.
+//
+// To do so, copy this file to rn-cli.config.js before running react-native.
+var path = require("path");
+var config = {
+    getProjectRoots() {
+        return [
+            // Keep your project directory.
+            path.resolve(__dirname),
+
+            // Include your forked package as a new root.
+            path.resolve(__dirname, "../../")
+        ];
+    },
+    extraNodeModules: {
+        react: path.resolve(__dirname, "node_modules/react")
+    }
+}
+module.exports = config;

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -24,15 +24,23 @@ export default class TestScope {
     this.run.bind(this);
   }
 
-  // Internal: Synchronously run each test case one after the other, outputting
-  // on the console if the test case passes or fails. Also resets the app
-  // after each test case by changing the component key to force React to
-  // re-render the entire component tree.
+  // Internal: Start tests after optional delay time.
   async run() {
     if (this.startDelay) {
       await this.pause(this.startDelay);
     }
-    
+    this.runTests();
+  }
+
+  // Internal: Synchronously run each test case one after the other, outputting
+  // on the console if the test case passes or fails, and adding to testResult
+  // array for reporting purposes.
+  // Resets the app after each test case by changing the component key to force
+  // React to re-render the entire component tree.
+  async runTests() {
+    let testResults = [];
+    let errorCount = 0;
+
     const start = new Date();
     console.log(`Cavy test suite started at ${start}.`);
 
@@ -40,9 +48,16 @@ export default class TestScope {
       let {description, f} = this.testCases[i];
       try {
         await f.call(this);
-        console.log(`${description}  ✅`);
+        let successMsg = `${description}  ✅`;
+
+        console.log(successMsg);
+        testResults.push({message: successMsg, passed: true});
       } catch (e) {
-        console.warn(`${description}  ❌\n   ${e.message}`);
+        let errorMsg = `${description}  ❌\n   ${e.message}`;
+
+        console.warn(errorMsg);
+        testResults.push({message: errorMsg, passed: false});
+        errorCount += 1;
       }
       await this.component.clearAsync();
       this.component.reRender();
@@ -51,6 +66,38 @@ export default class TestScope {
     const stop = new Date();
     const duration = (stop - start) / 1000;
     console.log(`Cavy test suite stopped at ${stop}, duration: ${duration} seconds.`);
+
+    const report = {
+      results: testResults,
+      errorCount: errorCount,
+      duration: duration
+    }
+
+    await this.sendReport(report);
+  };
+
+  sendReport(report) {
+    const url = 'http://127.0.0.1:8082/report';
+    const options = {
+      method: 'POST',
+      body: JSON.stringify(report),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        console.log('Cavy test report successfully sent to cavy-cli');
+      })
+      .catch((error) => {
+        if (error.message.match(/Network request failed/)) {
+          console.group(`Cavy test report server is not running at ${url}`);
+          console.log('If you are not using cavy-cli you can ignore this warning.');
+          console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
+          console.groupEnd();
+        }
+      });
   }
 
   // Public: Find a component by its test hook identifier. Waits

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -12,7 +12,7 @@ class ComponentNotFoundError extends Error {
 
 export default class TestScope {
 
-  constructor(component, waitTime, startDelay) {
+  constructor(component, waitTime, startDelay, shouldSendReport) {
     this.component = component;
     this.testHooks = component.testHookStore;
 
@@ -20,6 +20,7 @@ export default class TestScope {
 
     this.waitTime = waitTime;
     this.startDelay = startDelay;
+    this.shouldSendReport = shouldSendReport;
 
     this.run.bind(this);
   }
@@ -73,7 +74,9 @@ export default class TestScope {
       duration: duration
     }
 
-    await this.sendReport(report);
+    if (this.shouldSendReport) {
+      await this.sendReport(report);
+    }
   };
 
   sendReport(report) {
@@ -93,8 +96,11 @@ export default class TestScope {
       .catch((error) => {
         if (error.message.match(/Network request failed/)) {
           console.group(`Cavy test report server is not running at ${url}`);
-          console.log('If you are not using cavy-cli you can ignore this warning.');
           console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
+          console.groupEnd();
+        } else {
+          console.group('Error sending test results')
+          console.warn(error.message);
           console.groupEnd();
         }
       });

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -25,6 +25,9 @@ import {
 //                     test execution begins.
 // clearAsyncStorage - A boolean to determine whether to clear AsyncStorage
 //                     between each test. Defaults to `false`.
+// sendReport        - Boolean, set this to `true` to have Cavy try and 
+//                     send a report to cavy-cli. Set to `false` by
+//                     default.
 //
 // Example
 //
@@ -66,7 +69,8 @@ export default class Tester extends Component {
   }
 
   async runTests() {
-    scope = new TestScope(this, this.props.waitTime, this.props.startDelay);
+    const scope = new TestScope(this, this.props.waitTime, this.props.startDelay,
+      this.props.sendReport);
     for (var i = 0; i < this.props.specs.length; i++) {
       await this.props.specs[i](scope);
     }
@@ -102,7 +106,8 @@ Tester.propTypes = {
   specs: PropTypes.arrayOf(PropTypes.func),
   waitTime: PropTypes.number,
   startDelay: PropTypes.number,
-  clearAsyncStorage: PropTypes.bool
+  clearAsyncStorage: PropTypes.bool,
+  sendReport: PropTypes.bool
 };
 
 Tester.childContextTypes = {
@@ -112,5 +117,6 @@ Tester.childContextTypes = {
 Tester.defaultProps = {
   waitTime: 2000,
   startDelay: 0,
-  clearAsyncStorage: false
+  clearAsyncStorage: false,
+  sendReport: false
 }


### PR DESCRIPTION
We're adding support for a new command line interface to Cavy!

This command-line tool is going to make it much easier to integrate Cavy with your favourite CI environment.

We're building the sample app with Circle CI as part of Cavy's own test suite.