### PR TITLE
 Implement `testable` Higher Order Component (HOC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .idea/
 .DS_Store
 *.log
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@ For information on how to use Cavy's **command line interface**, check out
 [cavy-cli][cli].
 
 ## Table of Contents
-- [How does it work?](#how-does-it-work)
-  - [CLI and continuous integration](#cli-and-continuous-integration)
-  - [Where does it fit in?](#where-does-it-fit-in)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [1. Set up the Tester](#1-set-up-the-tester)
-  - [2. Hook up components](#2-hook-up-components)
-  - [3. Write test cases](#3-write-test-cases)
-  - [Apps that use native code](#apps-that-use-native-code)
-- [Available spec helpers](#available-spec-helpers)
-- [Writing your own spec helpers](#writing-your-own-spec-helpers)
-- [FAQs](#faqs)
-- [Contributing](#contributing)
+
+* [How does it work?](#how-does-it-work)
+  * [CLI and continuous integration](#cli-and-continuous-integration)
+  * [Where does it fit in?](#where-does-it-fit-in)
+* [Installation](#installation)
+* [Usage](#usage)
+  * [1. Set up the Tester](#1-set-up-the-tester)
+  * [2. Hook up components](#2-hook-up-components)
+  * [3. Write test cases](#3-write-test-cases)
+  * [Apps that use native code](#apps-that-use-native-code)
+* [Available spec helpers](#available-spec-helpers)
+* [Writing your own spec helpers](#writing-your-own-spec-helpers)
+* [FAQs](#faqs)
+* [Contributing](#contributing)
 
 ## How does it work?
 
@@ -50,10 +51,10 @@ continuous integration can be found in the [cavy-cli README][cli].
 We built Cavy because, at the time of writing, React Native had only a handful
 of testing approaches available:
 
-1. Unit testing components ([Jest](https://github.com/facebook/jest)).
-2. Shallow-render testing components ([enzyme](https://github.com/airbnb/enzyme)).
-3. Testing within your native environment, using native JS hooks ([Appium](http://appium.io/)).
-4. Testing completely within your native environment ([XCTest](https://developer.apple.com/reference/xctest)).
+1.  Unit testing components ([Jest](https://github.com/facebook/jest)).
+2.  Shallow-render testing components ([enzyme](https://github.com/airbnb/enzyme)).
+3.  Testing within your native environment, using native JS hooks ([Appium](http://appium.io/)).
+4.  Testing completely within your native environment ([XCTest](https://developer.apple.com/reference/xctest)).
 
 Cavy fits in between shallow-render testing and testing within your native
 environment.
@@ -83,10 +84,10 @@ Import `Tester`, `TestHookStore` and your specs in your top-level JS file
 ```javascript
 // index.ios.js
 
-import React, { Component } from 'react';
-import { Tester, TestHookStore } from 'cavy';
-import AppSpec from './specs/AppSpec';
-import App from './app';
+import React, { Component } from "react";
+import { Tester, TestHookStore } from "cavy";
+import AppSpec from "./specs/AppSpec";
+import App from "./app";
 
 const testHookStore = new TestHookStore();
 
@@ -103,14 +104,14 @@ export default class AppWrapper extends Component {
 
 **Tester props**
 
-| Prop | Type | Description | Default |
-| :------------ |:---------------:| :--------------- | :---------------: |
-| specs (required) | Array | Your spec functions | - |
-| store (required) | TestHookStore | The newly instantiated TestHookStore component | - |
-| waitTime | Integer | Time in milliseconds that your tests should wait to find a component | 2000 |
-| startDelay | Integer | Time in milliseconds before test execution begins | 0 |
-| clearAsyncStorage | Boolean | If true, clears AsyncStorage between each test e.g. to remove a logged in user | false |
-| sendReport | Boolean | If true, Cavy sends a report to [cavy-cli][cli] | false |
+| Prop              |     Type      | Description                                                                    | Default |
+| :---------------- | :-----------: | :----------------------------------------------------------------------------- | :-----: |
+| specs (required)  |     Array     | Your spec functions                                                            |    -    |
+| store (required)  | TestHookStore | The newly instantiated TestHookStore component                                 |    -    |
+| waitTime          |    Integer    | Time in milliseconds that your tests should wait to find a component           |  2000   |
+| startDelay        |    Integer    | Time in milliseconds before test execution begins                              |    0    |
+| clearAsyncStorage |    Boolean    | If true, clears AsyncStorage between each test e.g. to remove a logged in user |  false  |
+| sendReport        |    Boolean    | If true, Cavy sends a report to [cavy-cli][cli]                                |  false  |
 
 ### 2. Hook up components
 
@@ -121,22 +122,34 @@ Add a test hook to any components you want to test by adding a ref and using the
 identifier used in tests. It takes an optional second argument in case
 you also want to set your own ref generating function.
 
+In addition to that, you may want to use the Higher Order Component (HOC) `testable`
+that hooks the `generateTestHook` function to the component passed and sets the `ref`
+property with the param to the first function. Note that in this case, you do not need
+to hook nor wrap the component upfront, as this hook and wrap is done by the HOC.
+
 ```javascript
 // src/Scene.js
 
 import React, { Component } from 'react';
 import { TextInput } from 'react-native';
-import { hook } from 'cavy';
+import { hook, testable } from 'cavy';
+
+const Input = ({onChangeText}) => (
+  <TextInput
+    onChangeText={onChangeText}
+  />
+);
+
+const TestableInput = testable('Scene.TextInput')(Input)
 
 class Scene extends Component {
   render() {
     return (
       <View>
-        <TextInput
-          ref={this.props.generateTestHook('Scene.TextInput')}
+        <TestableInput
           onChangeText={...}
         />
-      </View>      
+      </View>
     );
   }
 }
@@ -156,11 +169,11 @@ helper functions.
 // specs/AppSpec.js
 
 export default function(spec) {
-  spec.describe('My feature', function() {
-    spec.it('works', async function() {
-      await spec.fillIn('Scene.TextInput', 'some string')
-      await spec.press('Scene.button');
-      await spec.exists('NextScene');
+  spec.describe("My feature", function() {
+    spec.it("works", async function() {
+      await spec.fillIn("Scene.TextInput", "some string");
+      await spec.press("Scene.button");
+      await spec.exists("NextScene");
     });
   });
 }
@@ -175,19 +188,19 @@ your `AppWrapper` as the main entry point with `AppRegistry` instead of your
 current `App` component:
 
 ```javascript
-AppRegistry.registerComponent('AppWrapper', () => AppWrapper);
+AppRegistry.registerComponent("AppWrapper", () => AppWrapper);
 ```
 
 ## Available spec helpers
 
-| Function | Description |
-| :------------ | :--------------- |
-| `fillIn(identifier, str)` | Fills in the identified component with the string<br>Component must respond to `onChangeText` |
-| `press(identifier)` | Presses the identified component<br>Component must respond to `onPress` |
-| `pause(integer)` | Pauses the test for this length of time (milliseconds)<br>Useful if you need to allow time for a response to be received before progressing |
-| `exists(identifier)` | Returns `true` if the component can be identified (i.e. is currently on screen) |
-| `notExists(identifier)` | As above, but checks for the absence of the component |
-| `findComponent(identifier)` | Returns the identified component<br>Can be used if your component doesn't respond to either `onChangeText` or `onPress`<br>For example:<br>```const picker = await spec.findComponent('Scene.modalPicker');```<br>```picker.open();```|
+| Function                    | Description                                                                                                                                                                                                                    |
+| :-------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fillIn(identifier, str)`   | Fills in the identified component with the string<br>Component must respond to `onChangeText`                                                                                                                                  |
+| `press(identifier)`         | Presses the identified component<br>Component must respond to `onPress`                                                                                                                                                        |
+| `pause(integer)`            | Pauses the test for this length of time (milliseconds)<br>Useful if you need to allow time for a response to be received before progressing                                                                                    |
+| `exists(identifier)`        | Returns `true` if the component can be identified (i.e. is currently on screen)                                                                                                                                                |
+| `notExists(identifier)`     | As above, but checks for the absence of the component                                                                                                                                                                          |
+| `findComponent(identifier)` | Returns the identified component<br>Can be used if your component doesn't respond to either `onChangeText` or `onPress`<br>For example:<br>`const picker = await spec.findComponent('Scene.modalPicker');`<br>`picker.open();` |
 
 ## Writing your own spec helpers
 
@@ -202,20 +215,21 @@ where you want the test to fail. For example, the following tests whether a `<Te
 export async function containsText(component, text) {
   if (!component.props.children.includes(text)) {
     throw new Error(`Could not find text ${text}`);
-  };
+  }
 }
 ```
+
 ```javascript
 // specs/AppSpec.js
 
-import { containsText } from './helpers';
+import { containsText } from "./helpers";
 
 export default function(spec) {
-  spec.describe('Changing the text', function() {
-    spec.it('works', async function() {
-      await spec.press('Scene.button');
-      const text = await spec.findComponent('Scene.text');
-      await containsText(text, 'you pressed the button');
+  spec.describe("Changing the text", function() {
+    spec.it("works", async function() {
+      await spec.press("Scene.button");
+      const text = await spec.findComponent("Scene.text");
+      await containsText(text, "you pressed the button");
     });
   });
 }
@@ -247,15 +261,17 @@ What that looks like specifically, we're not 100% sure yet. We're very happy to
 discuss possible alternatives!
 
 ## Contributing
+
 Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
-- Check out the latest master to make sure the feature hasn't been implemented
+
+* Check out the latest master to make sure the feature hasn't been implemented
   or the bug hasn't been fixed yet.
-- Check out the issue tracker to make sure someone already hasn't requested it
+* Check out the issue tracker to make sure someone already hasn't requested it
   and/or contributed it.
-- Fork the project.
-- Start a feature/bugfix branch.
-- Commit and push until you are happy with your contribution.
-- Please try not to mess with the package.json, version, or history. If you
+* Fork the project.
+* Start a feature/bugfix branch.
+* Commit and push until you are happy with your contribution.
+* Please try not to mess with the package.json, version, or history. If you
   want to have your own version, or is otherwise necessary, that is fine, but
   please isolate to its own commit so we can cherry-pick around it.
 

--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@ import hook from './src/hook';
 import Tester from './src/Tester';
 import TestHookStore from './src/TestHookStore';
 import wrap from './src/wrap';
+import testable from './src/testable';
 
 const Cavy = {
   hook,
   Tester,
   TestHookStore,
-  wrap
+  wrap,
+  testable
 };
 
 module.exports = Cavy;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "create-react-class": "^15.6.0",
     "hoist-non-react-statics": "^2.5.0",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "recompose": "^0.26.0"
   },
   "devDependencies": {
     "babel-jest": "^21.2.0",

--- a/sample-app/EmployeeDirectory/app/EmployeeDetails.js
+++ b/sample-app/EmployeeDirectory/app/EmployeeDetails.js
@@ -48,7 +48,11 @@ export default class EmployeeDetails extends Component {
         directReports =
           <FlatList style={styles.list}
                     data={this.state.reports}
-                    renderItem={ ({item}) => <EmployeeListItem navigation={this.props.navigation} data={item} /> }
+                    renderItem={ ({item}) =>
+                    <EmployeeListItem
+                      onPress={() => this.props.navigation.navigate('EmployeeDetails', { employeeId: item.id })}
+                      {...item}
+                    />}
                     ItemSeparatorComponent={(sectionId, rowId) => <View key={rowId} style={styles.separator} />}
                     keyExtractor={(item, index) => item.id.toString()}
           />;

--- a/sample-app/EmployeeDirectory/app/EmployeeList.js
+++ b/sample-app/EmployeeDirectory/app/EmployeeList.js
@@ -33,7 +33,11 @@ export default class EmployeeList extends Component {
     });
   }
 
-  _renderItem = ({item}) => <EmployeeListItem navigation={this.props.navigation} data={item} />;
+  _renderItem = ({item}) =>
+    <EmployeeListItem
+      onPress={() => this.props.navigation.navigate('EmployeeDetails', { employeeId: item.id })}
+      {...item}
+    />;
   _itemSeparator = (sectionId, rowId) => <View key={rowId} style={styles.separator} />;
   _headerSearchBar = () => <SearchBar onChange={this.search.bind(this)} />;
   _keyExtractor = (item, index) => item.id.toString();

--- a/sample-app/EmployeeDirectory/app/EmployeeListItem.js
+++ b/sample-app/EmployeeDirectory/app/EmployeeListItem.js
@@ -1,30 +1,31 @@
 import React, { Component } from 'react';
-import { View, Text, Image, TouchableHighlight, StyleSheet } from 'react-native';
+import {
+  View,
+  Text,
+  Image,
+  TouchableHighlight,
+  StyleSheet
+} from 'react-native';
 
-import { hook } from 'cavy';
+import { testable } from 'cavy';
 
-class EmployeeListItem extends Component {
+const EmployeeListItem = props => (
+  <TouchableHighlight
+    underlayColor={'#EEEEEE'}
+  >
+    <View style={styles.container}>
+      <Image source={{ uri: props.picture }} style={styles.picture} />
+      <View>
+        <Text>
+          {props.firstName} {props.lastName}
+        </Text>
+        <Text style={styles.title}>{props.title}</Text>
+      </View>
+    </View>
+  </TouchableHighlight>
+);
 
-  render() {
-    const { state, navigate } = this.props.navigation;
-    return (
-      <TouchableHighlight
-        ref={this.props.generateTestHook(`${state.routeName}.${this.props.data.firstName}${this.props.data.lastName}`)}
-        onPress={ () => navigate('EmployeeDetails', {employeeId: this.props.data.id}) }
-        underlayColor={'#EEEEEE'}>
-        <View style={styles.container}>
-          <Image source={{uri: this.props.data.picture}} style={styles.picture} />
-          <View>
-            <Text>{this.props.data.firstName} {this.props.data.lastName}</Text>
-            <Text style={styles.title}>{this.props.data.title}</Text>
-          </View>
-        </View>
-      </TouchableHighlight>
-    )
-  }
-}
-
-export default hook(EmployeeListItem);
+export default testable('EmployeeListItem', 'id')(EmployeeListItem);
 
 const styles = StyleSheet.create({
   container: {

--- a/sample-app/EmployeeDirectory/specs/EmployeeListSpec.js
+++ b/sample-app/EmployeeDirectory/specs/EmployeeListSpec.js
@@ -3,10 +3,10 @@ export default function(spec) {
   spec.describe('Listing the employees', function() {
 
     spec.it('filters the list by search input', async function() {
-      await spec.exists('EmployeeList.AnupGupta');
+      await spec.exists('EmployeeListItem.2');
       await spec.fillIn('SearchBar.TextInput', 'Amy');
-      await spec.notExists('EmployeeList.AnupGupta');
-      await spec.exists('EmployeeList.AmyTaylor');
+      await spec.notExists('EmployeeListItem.2');
+      await spec.exists('EmployeeListItem.1');
     });
 
   });
@@ -15,7 +15,7 @@ export default function(spec) {
 
     spec.it('shows a button to email them', async function() {
       await spec.fillIn('SearchBar.TextInput', 'Amy');
-      await spec.press('EmployeeList.AmyTaylor');
+      await spec.press('EmployeeListItem.1');
       await spec.pause(1000);
       await spec.exists('ActionBar.EmailButton');
     });

--- a/src/testable.js
+++ b/src/testable.js
@@ -1,12 +1,23 @@
 import { compose, toClass, mapProps } from "recompose";
 import hook from "./hook";
 
-const mapRef = nameRef =>
-  mapProps(({ generateTestHook, ...args }) => ({
-    ...args,
-    ref: generateTestHook(nameRef)
+const updateNameRef = (props, nameRef, propName) => {
+  if (propName) {
+    const propValue = props[propName];
+    return propValue ? `${nameRef}.${propValue}` : nameRef;
+  }
+  return nameRef;
+};
+const mapRef = nameRef => propName => {
+  return mapProps(props => ({
+    ...props,
+    ref: props.generateTestHook(updateNameRef(props, nameRef, propName))
   }));
+};
 
-const enhancedTestable = nameRef => compose(hook, mapRef(nameRef), toClass);
+const enhancedTestable = nameRef => propName =>
+  compose(hook, mapRef(nameRef)(propName), toClass);
 
-export default nameRef => enhancedTestable(nameRef);
+export default (nameRef, propName = null) =>
+  enhancedTestable(nameRef)(propName)
+

--- a/src/testable.js
+++ b/src/testable.js
@@ -1,0 +1,12 @@
+import { compose, toClass, mapProps } from "recompose";
+import hook from "./hook";
+
+const mapRef = nameRef =>
+  mapProps(({ generateTestHook, ...args }) => ({
+    ...args,
+    ref: generateTestHook(nameRef)
+  }));
+
+const enhancedTestable = nameRef => compose(hook, mapRef(nameRef), toClass);
+
+export default nameRef => enhancedTestable(nameRef);


### PR DESCRIPTION
- Implement component that helps injecting `ref` into a component by abstracting that into a HOC
- Documented additions

Note: This PR has potential conflicts with https://github.com/pixielabs/cavy/pull/77, will resolve them if any of them get merged. 