### PR TITLE
Remove console.warn when overwriting a component

### DIFF
--- a/src/TestHookStore.js
+++ b/src/TestHookStore.js
@@ -19,10 +19,6 @@ export default class TestHookStore {
   //
   // Returns undefined.
   add(identifier, component) {
-    if (this.hooks[identifier]) {
-      console.warn(`A component for ${identifier} has already been registered. Overwriting.`);
-    }
-
     this.hooks[identifier] = component;
   }
 

--- a/src/__test__/TestHookStore.test.js
+++ b/src/__test__/TestHookStore.test.js
@@ -14,15 +14,6 @@ describe("TestHookStore", () => {
     expect(testHookStore.get("key")).toEqual("value");
   })
 
-  it("warns when adding an existing component", () => {
-    const testHookStore = new TestHookStore();
-    testHookStore.add("key", "value1");
-    const warnSpy = jest.spyOn(global.console, 'warn');
-    testHookStore.add("key", "value2");
-
-    expect(warnSpy).toBeCalled();
-  });
-
   it("overrides when adding an existing component", () => {
     const testHookStore = new TestHookStore();
     testHookStore.add("key", "value1");


### PR DESCRIPTION
Related to #86 and #84. It's clear this warning isn't very useful, and the yellow box gets in the way, so let's remove it.

This will be a minor version bump.