### PR TITLE
fix async storage issue when there is no entry

### DIFF
--- a/src/Tester.js
+++ b/src/Tester.js
@@ -84,7 +84,7 @@ export default class Tester extends Component {
   async clearAsync() {
     if (this.props.clearAsyncStorage) {
       try {
-        await AsyncStorage.clear();
+        await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove)
       } catch(e) {
         console.warn("[Cavy] failed to clear AsyncStorage:", e);
       }


### PR DESCRIPTION
## Current Issue fixed by this PR:
- Using `Tester` with `clearAsyncStorage` throws on iOS when the async storage is empty. This has been reported [in stackoverflow](https://stackoverflow.com/questions/46736268/react-native-asyncstorage-clear-is-failing-on-ios) and in this repo #53 
- I encountered this error when testing on a simulator `iphone X`

