### PR TITLE
Implement `beforeEach` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.0
+
+- Add a `beforeEach` function that can be used on a per-spec basis. Thanks to [PatrickBRT](https://github.com/PatrickBRT) whose work inspired our approach!
+- **BREAKING** Clear AsyncStorage and re-render the app before each test runs.
+No final resetting of the app at the end of the test suite.
+
 # 1.1.0
 
 - Un-deprecate `wrap` (was deprecated in 0.6.0) and rewrite it using React

--- a/README.md
+++ b/README.md
@@ -199,10 +199,29 @@ Write your spec functions referencing your hooked-up components.
 [See below](#available-spec-helpers) for a list of currently available spec
 helper functions.
 
+You can use `spec.beforeEach` to call a function before each test runs. The
+`beforeEach` function will be called after `AsyncStorage` is cleared but before
+the app re-renders and the test is run i.e. the order of actions for each test
+execution is:
+
+1. AsyncStorage is cleared (if the `clearAsyncStorage` prop is set to true in `Tester`)
+2. The `beforeEach` function is called (if defined for this test)
+3. The app is re-rendered
+4. The test is run
+
+At the moment, there is no beforeEach function in Cavy that is called _after_
+the app is re-rendered. We suggest that you create your own helper function to
+call from within your tests if you need this functionality.
+
 ```javascript
 // specs/AppSpec.js
 
 export default function(spec) {
+
+  spec.beforeEach(function() {
+    // This function will run before each test in this spec file.
+  });
+
   spec.describe('My feature', function() {
     spec.it('works', async function() {
       await spec.fillIn('Scene.TextInput', 'some string')

--- a/README.md
+++ b/README.md
@@ -204,14 +204,14 @@ You can use `spec.beforeEach` to call a function before each test runs. The
 the app re-renders and the test is run i.e. the order of actions for each test
 execution is:
 
-1. AsyncStorage is cleared (if the `clearAsyncStorage` prop is set to true in `Tester`)
+1. AsyncStorage is cleared (if the `clearAsyncStorage` prop is set to true in
+   `Tester`)
 2. The `beforeEach` function is called (if defined for this test)
 3. The app is re-rendered
 4. The test is run
 
-At the moment, there is no beforeEach function in Cavy that is called _after_
-the app is re-rendered. We suggest that you create your own helper function to
-call from within your tests if you need this functionality.
+If you need to run shared code at the start of multiple tests _after_ the app
+is re-rendered, create your own helper function to call from within your tests.
 
 ```javascript
 // specs/AppSpec.js

--- a/sample-app/CavyDirectory/specs/EmployeeListSpec.js
+++ b/sample-app/CavyDirectory/specs/EmployeeListSpec.js
@@ -1,5 +1,9 @@
 export default function(spec) {
 
+  spec.beforeEach(function(){
+    console.log("i'm a beforeEach fuction");
+  })
+
   spec.describe('Listing the employees', function() {
 
     spec.it('filters the list by search input', async function() {

--- a/sample-app/CavyDirectory/specs/EmployeeListSpec.js
+++ b/sample-app/CavyDirectory/specs/EmployeeListSpec.js
@@ -1,9 +1,5 @@
 export default function(spec) {
-
-  spec.beforeEach(function(){
-    console.log("i'm a beforeEach fuction");
-  })
-
+  
   spec.describe('Listing the employees', function() {
 
     spec.it('filters the list by search input', async function() {

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -1,0 +1,109 @@
+export default class TestRunner {
+
+  constructor(component, testSuites, startDelay, sendReport) {
+    this.component = component;
+    this.testSuites = testSuites;
+    this.startDelay = startDelay;
+    this.shouldSendReport = sendReport;
+  }
+
+  // Internal: Start tests after optional delay time.
+  async run() {
+    if (this.startDelay) { await this.pause(this.startDelay)};
+    this.runTests();
+  }
+
+  // Internal: Synchronously run each test case one after the other, outputting
+  // on the console if the test case passes or fails, and adding to testResult
+  // array for reporting purposes.
+  // Resets the app after each test case by changing the component key to force
+  // React to re-render the entire component tree.
+  async runTests() {
+    let testResults = [];
+    let errorCount = 0;
+
+    const start = new Date();
+    console.log(`Cavy test suite started at ${start}.`);
+
+    for (let i = 0; i < this.testSuites.length; i++) {
+
+      for (let j = 0; j < this.testSuites[i].testCases.length; j++) {
+
+        let { description, f } = this.testSuites[i].testCases[j];
+        try {
+          await f.call(this.testSuites[i]);
+          let successMsg = `${description}  ✅`;
+
+          console.log(successMsg);
+          testResults.push({message: successMsg, passed: true});
+        } catch (e) {
+          let errorMsg = `${description}  ❌\n   ${e.message}`;
+
+          console.warn(errorMsg);
+          testResults.push({message: errorMsg, passed: false});
+          errorCount += 1;
+        }
+        await this.component.clearAsync();
+        this.component.reRender();
+      }
+    }
+
+    const stop = new Date();
+    const duration = (stop - start) / 1000;
+    console.log(`Cavy test suite stopped at ${stop}, duration: ${duration} seconds.`);
+
+    const report = {
+      results: testResults,
+      errorCount: errorCount,
+      duration: duration
+    }
+
+    if (this.shouldSendReport) { await this.sendReport(report) };
+  }
+
+
+  // Internal: Make a post request to the cavy-cli server with the test report.
+  sendReport(report) {
+    const url = 'http://127.0.0.1:8082/report';
+    const options = {
+      method: 'POST',
+      body: JSON.stringify(report),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    };
+
+    return fetch(url, options)
+      .then((response) => {
+        console.log('Cavy test report successfully sent to cavy-cli');
+      })
+      .catch((error) => {
+        if (error.message.match(/Network request failed/)) {
+          console.group(`Cavy test report server is not running at ${url}`);
+          console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
+          console.groupEnd();
+        } else {
+          console.group('Error sending test results')
+          console.warn(error.message);
+          console.groupEnd();
+        }
+      });
+  }
+
+  // Public: Pause the test for a specified length of time, perhaps to allow
+  // time for a request response to be received.
+  //
+  // time - Integer length of time to pause for (in milliseconds).
+  //
+  // Returns a promise, use await when calling this function.
+  async pause(time) {
+    let promise = new Promise((resolve, reject) => {
+      setTimeout(function() {
+        resolve();
+      }, time);
+    });
+
+    return promise;
+  }
+
+}

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -1,3 +1,15 @@
+// Internal: TestRunner is responsible for actually running through each
+// suite of tests and executing the specs.
+//
+// It also presents the test results and ensures a report is sent to cavy-cli
+// if necessary.
+//
+// component  - the Tester component within which the app is wrapped.
+// testSuites - an array of TestScopes, each of which relate to a single suite
+//              of tests.
+// startDelay - length of time in ms that cavy should wait before starting
+//              tests.
+// sendReport - boolean - if true, attempt to send a test report to cavy-cli.
 export default class TestRunner {
 
   constructor(component, testSuites, startDelay, sendReport) {
@@ -55,7 +67,6 @@ export default class TestRunner {
   // 3. Re-renders the app
   // 4. Runs the test
   async runTest(scope, test) {
-
     await this.component.clearAsync();
     if (scope.beforeEach) { await scope.beforeEach.call(scope) };
     this.component.reRender();

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -37,7 +37,7 @@ export default class TestRunner {
 
     // Compile the report object.
     const report = {
-      results: this.stResults,
+      results: this.testResults,
       errorCount: this.errorCount,
       duration: duration
     }

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -12,98 +12,11 @@ class ComponentNotFoundError extends Error {
 
 export default class TestScope {
 
-  constructor(component, waitTime, startDelay, shouldSendReport) {
+  constructor(component, waitTime) {
     this.component = component;
     this.testHooks = component.testHookStore;
-
     this.testCases = [];
-
     this.waitTime = waitTime;
-    this.startDelay = startDelay;
-    this.shouldSendReport = shouldSendReport;
-
-    this.run.bind(this);
-  }
-
-  // Internal: Start tests after optional delay time.
-  async run() {
-    if (this.startDelay) {
-      await this.pause(this.startDelay);
-    }
-    this.runTests();
-  }
-
-  // Internal: Synchronously run each test case one after the other, outputting
-  // on the console if the test case passes or fails, and adding to testResult
-  // array for reporting purposes.
-  // Resets the app after each test case by changing the component key to force
-  // React to re-render the entire component tree.
-  async runTests() {
-    let testResults = [];
-    let errorCount = 0;
-
-    const start = new Date();
-    console.log(`Cavy test suite started at ${start}.`);
-
-    for (let i = 0; i < this.testCases.length; i++) {
-      let {description, f} = this.testCases[i];
-      try {
-        await f.call(this);
-        let successMsg = `${description}  ✅`;
-
-        console.log(successMsg);
-        testResults.push({message: successMsg, passed: true});
-      } catch (e) {
-        let errorMsg = `${description}  ❌\n   ${e.message}`;
-
-        console.warn(errorMsg);
-        testResults.push({message: errorMsg, passed: false});
-        errorCount += 1;
-      }
-      await this.component.clearAsync();
-      this.component.reRender();
-    }
-
-    const stop = new Date();
-    const duration = (stop - start) / 1000;
-    console.log(`Cavy test suite stopped at ${stop}, duration: ${duration} seconds.`);
-
-    const report = {
-      results: testResults,
-      errorCount: errorCount,
-      duration: duration
-    }
-
-    if (this.shouldSendReport) {
-      await this.sendReport(report);
-    }
-  };
-
-  sendReport(report) {
-    const url = 'http://127.0.0.1:8082/report';
-    const options = {
-      method: 'POST',
-      body: JSON.stringify(report),
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    };
-
-    return fetch(url, options)
-      .then((response) => {
-        console.log('Cavy test report successfully sent to cavy-cli');
-      })
-      .catch((error) => {
-        if (error.message.match(/Network request failed/)) {
-          console.group(`Cavy test report server is not running at ${url}`);
-          console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
-          console.groupEnd();
-        } else {
-          console.group('Error sending test results')
-          console.warn(error.message);
-          console.groupEnd();
-        }
-      });
   }
 
   // Public: Find a component by its test hook identifier. Waits

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -1,8 +1,5 @@
-// Internal: Wrapper around an app being tested, and a bunch of test cases.
-//
-// The TestScope also includes all the functions available when writing your
-// spec files.
-
+// Custom error returned when Cavy cannot find the component in the
+// TestHookStore.
 class ComponentNotFoundError extends Error {
   constructor(message) {
     super(message);
@@ -10,6 +7,13 @@ class ComponentNotFoundError extends Error {
   }
 }
 
+// Internal: TestScope is responsible for building up testCases to be run by
+// the TestRunner, and includes all the functions available when writing these
+// specs.
+//
+// component - the Tester component within which the app is wrapped.
+// waitTime  - length of time in ms that cavy should wait before giving up on
+//             finding a component in the testHookStore.
 export default class TestScope {
 
   constructor(component, waitTime) {

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -93,6 +93,13 @@ export default class TestScope {
     this.testCases.push({description, f});
   }
 
+  // Public: Runs a function before each test case.
+  //
+  // f - the function to run
+  beforeEach(f) {
+    this.beforeEach = f;
+  }
+
   // Public: Fill in a `TextInput`-compatible component with a string value.
   // Your component should respond to the property `onChangeText`.
   //

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -45,7 +45,6 @@ import TestRunner from './TestRunner';
 //       );
 //     }
 //   }
-
 export const TesterContext = React.createContext();
 
 export default class Tester extends Component {
@@ -62,6 +61,7 @@ export default class Tester extends Component {
     this.runTests();
   }
 
+  // Run all test suites.
   async runTests() {
     const { specs, waitTime, startDelay, sendReport } = this.props;
     const testSuites = [];
@@ -71,7 +71,7 @@ export default class Tester extends Component {
       await specs[i](scope);
       testSuites.push(scope);
     }
-
+    // Instantiate the test runner, pass in the array of suites and run the tests.
     const runner = new TestRunner(this, testSuites, startDelay, sendReport);
     runner.run();
   }
@@ -80,6 +80,7 @@ export default class Tester extends Component {
     this.setState({key: Math.random()});
   }
 
+  // Clear everything from AsyncStorage, warn if anything goes wrong.
   async clearAsync() {
     if (this.props.clearAsyncStorage) {
       try {

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -64,7 +64,6 @@ export default class Tester extends Component {
 
   async runTests() {
     const { specs, waitTime, startDelay, sendReport } = this.props;
-
     const testSuites = [];
     // Iterate over each suite of specs and create a new TestScope for each.
     for (var i = 0; i < specs.length; i++) {

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -64,8 +64,8 @@ export default class Tester extends Component {
 
   async runTests() {
     const { specs, waitTime, startDelay, sendReport } = this.props;
+
     const testSuites = [];
-    
     // Iterate over each suite of specs and create a new TestScope for each.
     for (var i = 0; i < specs.length; i++) {
       const scope = new TestScope(this, waitTime);

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -4,6 +4,7 @@ import { AsyncStorage } from 'react-native';
 
 import TestHookStore from './TestHookStore';
 import TestScope from './TestScope';
+import TestRunner from './TestRunner';
 
 // Public: Wrap your entire app in Tester to run tests against that app,
 // interacting with registered components in your test cases via the Cavy
@@ -62,12 +63,18 @@ export default class Tester extends Component {
   }
 
   async runTests() {
-    const scope = new TestScope(this, this.props.waitTime, this.props.startDelay,
-      this.props.sendReport);
-    for (var i = 0; i < this.props.specs.length; i++) {
-      await this.props.specs[i](scope);
+    const { specs, waitTime, startDelay, sendReport } = this.props;
+    const testSuites = [];
+    
+    // Iterate over each suite of specs and create a new TestScope for each.
+    for (var i = 0; i < specs.length; i++) {
+      const scope = new TestScope(this, waitTime);
+      await specs[i](scope);
+      testSuites.push(scope);
     }
-    scope.run();
+
+    const runner = new TestRunner(this, testSuites, startDelay, sendReport);
+    runner.run();
   }
 
   reRender() {


### PR DESCRIPTION
**Includes**
- Adding the ability for users to call a `beforeEach` function before each test in a suite.
- As it stands, `spec.beforeEach` can only be set on a per spec basis and cannot be nested
- As per the discussion on #57 , `beforeEach` is called after AsyncStorage is cleared, but before the app is re-rendered. This allows users to manipulate state before the app is re-rendered.
- No `afterEach`, in our opinion people shouldn't really use `afterEach`... 
- There's also no `beforeAll` yet as per the discussion on suitability of this functionality in #57.

```js
export default function(spec) {
  spec.beforeEach(function() { });

  spec.describe('My feature', function() {
    spec.it('works', async function() {
    });
  });
}
```

**To do**
- [ ] Once we're happy with functionality, I'll add to the README. We should let users know _when_ `beforeEach` will be called and suggest an alternative helper method approach if you want to run code after app re-render but before each test.

**Notes**
- There's repetition of a pause function.
- The app now re-renders before each test case, causing a double render on app boot when running tests. I attempted to solve this by setting state on `Tester` (`testsStarted: false`) and only rendering children in this component when `this.state.testsStarted`. The `TestRunner` then called a function to change this to true when it re-rendered the app.

This worked, but gave the following warning:

![Screenshot 2019-05-02 at 14 55 54](https://user-images.githubusercontent.com/18436946/57083203-12827080-6cf0-11e9-87f6-9df6d5ff43e2.png)

Therefore, I've left the double render in for now; I can add it to the issue tracker.

**Compatibility**
- This adds more functionality to Cavy, and does not fundamentally change the way people should use Cavy. However, the order of action when running each test case is now different:

Before:
1. Run test
2. Clear AsyncStorage
3. Re-render app

Now:
1. Clear AsyncStorage
2. Call beforeEach function
3. Re-render app
4. Run test

This change in ordering actually fixes this bug #91 