### PR TITLE
Deprecate `sendReport` prop, attempt to send report to cavy-cli by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ is running on a host device (e.g. your Android or iOS simulator).
 
 ### CLI and continuous integration
 
-By default, Cavy outputs test results to the console when your app runs.
+By default, Cavy outputs test results to the console when your app boots.
 However, you can also run Cavy tests directly from the command line using
-Cavy's own command line interface - [cavy-cli][cli]. Just set the `sendReport`
-prop on your `<Tester>` component to `true` (see below).
+Cavy's own command line interface - [cavy-cli][cli].
 
 Further details on how you can use cavy-cli to fully automate your tests with
 continuous integration can be found in the [cavy-cli README][cli].
@@ -87,9 +86,6 @@ Import `Tester`, `TestHookStore` and your specs in your top-level JS file
 (typically this is your `index.{ios,android}.js` files). Instantiate a new
 `TestHookStore` and render your app inside a `Tester`.
 
-The example below assumes that you are running your tests via
-**[cavy-cli][cli]**, and therefore sets the `sendReport` prop to `true`.
-
 ```javascript
 // index.ios.js
 
@@ -103,7 +99,7 @@ const testHookStore = new TestHookStore();
 export default class AppWrapper extends Component {
   render() {
     return (
-      <Tester specs={[AppSpec]} store={testHookStore} sendReport={true}>
+      <Tester specs={[AppSpec]} store={testHookStore}>
         <App />
       </Tester>
     );

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ export default class AppWrapper extends Component {
 | waitTime | Integer | Time in milliseconds that your tests should wait to find a component | 2000 |
 | startDelay | Integer | Time in milliseconds before test execution begins | 0 |
 | clearAsyncStorage | Boolean | If true, clears AsyncStorage between each test e.g. to remove a logged in user | false |
-| sendReport | Boolean | If true, Cavy sends a report to [cavy-cli][cli] | false |
 
 ### 2. Hook up components
 
@@ -181,7 +180,7 @@ import { useCavy } from 'cavy';
 
 export default () => {
   const generateTestHook = useCavy();
-  
+
   return (
     <View>
       <TextInput

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ is running on a host device (e.g. your Android or iOS simulator).
 
 ### CLI and continuous integration
 
-By default, Cavy outputs test results to the console when your app boots.
-However, you can also run Cavy tests directly from the command line using
-Cavy's own command line interface - [cavy-cli][cli].
+When your app boots, Cavy will run your test suite and output the results to the
+console. Cavy will also check whether there is a cavy-cli server running and,
+if so, send a report of the test results.
+
+You can also run Cavy tests directly using [cavy-cli][cli].
 
 Further details on how you can use cavy-cli to fully automate your tests with
 continuous integration can be found in the [cavy-cli README][cli].

--- a/sample-app/CavyDirectory/index.js
+++ b/sample-app/CavyDirectory/index.js
@@ -18,7 +18,7 @@ class AppWrapper extends Component {
   render() {
     return (
       <Tester specs={[EmployeeListSpec]} store={testHookStore} waitTime={1000}
-        startDelay={3000} sendReport={true}>
+        startDelay={3000}>
         <EmployeeDirectoryApp />
       </Tester>
     );

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -48,13 +48,8 @@ export default class TestRunner {
     const duration = (stop - start) / 1000;
     console.log(`Cavy test suite stopped at ${stop}, duration: ${duration} seconds.`);
 
-    // Compile the report object.
-    const report = {
-      results: this.testResults,
-      errorCount: this.errorCount,
-      duration: duration
-    }
-
+    // Handle use of deprecated prop `sendReport` and honour previous expected
+    // behaviour by not reporting results if set to false;
     if (this.shouldSendReport != undefined) {
       const message = 'Deprecation warning: using the `sendReport` prop is ' +
                       'deprecated. By default, Cavy now checks whether the ' +
@@ -63,6 +58,13 @@ export default class TestRunner {
       console.warn(message);
 
       if (!this.shouldSendReport) return;
+    }
+
+    // Compile the report object.
+    const report = {
+      results: this.testResults,
+      errorCount: this.errorCount,
+      duration: duration
     }
 
     // Send report to reporter (default is cavy-cli)

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -11,10 +11,11 @@
 //              tests.
 export default class TestRunner {
 
-  constructor(component, testSuites, startDelay, sendReport) {
+  constructor(component, testSuites, startDelay, reporter, sendReport) {
     this.component = component;
     this.testSuites = testSuites;
     this.startDelay = startDelay;
+    this.reporter = reporter;
     // Using the sendReport prop is deprecated - cavy checks whether the
     // cavy-cli server is listening and sends a report if true.
     this.shouldSendReport = sendReport;
@@ -68,7 +69,7 @@ export default class TestRunner {
     }
 
     // Send report to reporter (default is cavy-cli)
-    await this.reportResults(report);
+    await this.reporter(report);
   }
 
   // Internal: Synchronously runs each test case within a test suite, outputting
@@ -100,44 +101,6 @@ export default class TestRunner {
       this.testResults.push({message: errorMsg, passed: false});
       // Increase error count for reporting.
       this.errorCount += 1;
-    }
-  }
-
-  // Internal: Check that cavy-cli server is running and if so, send report.
-  async reportResults(report) {
-    const url = 'http://127.0.0.1:8082/';
-
-    try {
-      const response = await fetch(url);
-      const text = await response.text();
-
-      if (text == 'cavy-cli running') {
-        return this.send(report);
-      } else {
-        throw new Error('Unexpected response');
-      }
-    } catch (e) {
-      console.log(`Skipping sending test report to cavy-cli - ${e.message}.`)
-    }
-  }
-
-  // Internal: Make a post request to the cavy-cli server with the test report.
-  async send(report) {
-    const url = 'http://127.0.0.1:8082/report';
-
-    const options = {
-      method: 'POST',
-      body: JSON.stringify(report),
-      headers: { 'Content-Type': 'application/json' }
-    };
-
-    try {
-      await fetch(url, options);
-      console.log('Cavy test report successfully sent to cavy-cli');
-    } catch (e) {
-      console.group('Error sending test results')
-      console.warn(e.message);
-      console.groupEnd();
     }
   }
 

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -11,10 +11,13 @@
 //              tests.
 export default class TestRunner {
 
-  constructor(component, testSuites, startDelay) {
+  constructor(component, testSuites, startDelay, sendReport) {
     this.component = component;
     this.testSuites = testSuites;
     this.startDelay = startDelay;
+    // Using the sendReport prop is deprecated - cavy checks whether the
+    // cavy-cli server is listening and sends a report if true.
+    this.shouldSendReport = sendReport;
     this.testResults = [];
     this.errorCount = 0;
   }
@@ -51,6 +54,17 @@ export default class TestRunner {
       errorCount: this.errorCount,
       duration: duration
     }
+
+    if (this.shouldSendReport != undefined) {
+      const message = 'Deprecation warning: using the `sendReport` prop is ' +
+                      'deprecated. By default, Cavy now checks whether the ' +
+                      'cavy-cli server is running and sends a report if a ' +
+                      'connection is detected.'
+      console.warn(message);
+
+      if (!this.shouldSendReport) return;
+    }
+
     // Send report to reporter (default is cavy-cli)
     await this.reportResults(report);
   }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -135,18 +135,8 @@ export default class TestRunner {
       await fetch(url, options);
       console.log('Cavy test report successfully sent to cavy-cli');
     } catch (e) {
-      this.handleError(e, url);
-    }
-  }
-
-  handleError(error, url) {
-    if (error.message.match(/Network request failed/)) {
-      console.group(`Cavy test report server is not running at ${url}`);
-      console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
-      console.groupEnd();
-    } else {
       console.group('Error sending test results')
-      console.warn(error.message);
+      console.warn(e.message);
       console.groupEnd();
     }
   }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -9,14 +9,12 @@
 //              of tests.
 // startDelay - length of time in ms that cavy should wait before starting
 //              tests.
-// sendReport - boolean - if true, attempt to send a test report to cavy-cli.
 export default class TestRunner {
 
-  constructor(component, testSuites, startDelay, sendReport) {
+  constructor(component, testSuites, startDelay) {
     this.component = component;
     this.testSuites = testSuites;
     this.startDelay = startDelay;
-    this.shouldSendReport = sendReport;
     this.testResults = [];
     this.errorCount = 0;
   }
@@ -53,8 +51,8 @@ export default class TestRunner {
       errorCount: this.errorCount,
       duration: duration
     }
-    // Send report to cavy-cli.
-    if (this.shouldSendReport) { await this.sendReport(report) };
+    // Send report to reporter (default is cavy-cli)
+    await this.sendReport(report);
   }
 
   // Internal: Synchronously runs each test case within a test suite, outputting

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -22,9 +22,6 @@ import TestRunner from './TestRunner';
 //                     test execution begins.
 // clearAsyncStorage - A boolean to determine whether to clear AsyncStorage
 //                     between each test. Defaults to `false`.
-// sendReport        - Boolean, set this to `true` to have Cavy try and
-//                     send a report to cavy-cli. Set to `false` by
-//                     default.
 //
 // Example
 //
@@ -63,7 +60,7 @@ export default class Tester extends Component {
 
   // Run all test suites.
   async runTests() {
-    const { specs, waitTime, startDelay, sendReport } = this.props;
+    const { specs, waitTime, startDelay } = this.props;
     const testSuites = [];
     // Iterate over each suite of specs and create a new TestScope for each.
     for (var i = 0; i < specs.length; i++) {
@@ -72,7 +69,7 @@ export default class Tester extends Component {
       testSuites.push(scope);
     }
     // Instantiate the test runner, pass in the array of suites and run the tests.
-    const runner = new TestRunner(this, testSuites, startDelay, sendReport);
+    const runner = new TestRunner(this, testSuites, startDelay);
     runner.run();
   }
 
@@ -105,13 +102,11 @@ Tester.propTypes = {
   specs: PropTypes.arrayOf(PropTypes.func),
   waitTime: PropTypes.number,
   startDelay: PropTypes.number,
-  clearAsyncStorage: PropTypes.bool,
-  sendReport: PropTypes.bool
+  clearAsyncStorage: PropTypes.bool
 };
 
 Tester.defaultProps = {
   waitTime: 2000,
   startDelay: 0,
-  clearAsyncStorage: false,
-  sendReport: false
+  clearAsyncStorage: false
 };

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -5,6 +5,7 @@ import { AsyncStorage } from 'react-native';
 import TestHookStore from './TestHookStore';
 import TestScope from './TestScope';
 import TestRunner from './TestRunner';
+import reporter from './reporter';
 
 // Public: Wrap your entire app in Tester to run tests against that app,
 // interacting with registered components in your test cases via the Cavy
@@ -52,6 +53,9 @@ export default class Tester extends Component {
       key: Math.random()
     };
     this.testHookStore = props.store;
+    // Default to sending a test report to cavy-cli if no custom reporter is
+    // supplied.
+    this.reporter = props.reporter || reporter;
   }
 
   componentDidMount() {
@@ -68,8 +72,9 @@ export default class Tester extends Component {
       await specs[i](scope);
       testSuites.push(scope);
     }
+
     // Instantiate the test runner, pass in the array of suites and run the tests.
-    const runner = new TestRunner(this, testSuites, startDelay, sendReport);
+    const runner = new TestRunner(this, testSuites, startDelay, this.reporter, sendReport);
     runner.run();
   }
 
@@ -103,6 +108,7 @@ Tester.propTypes = {
   waitTime: PropTypes.number,
   startDelay: PropTypes.number,
   clearAsyncStorage: PropTypes.bool,
+  reporter: PropTypes.func,
   // Deprecated (see note in TestRunner component).
   sendReport: PropTypes.bool
 };

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -60,7 +60,7 @@ export default class Tester extends Component {
 
   // Run all test suites.
   async runTests() {
-    const { specs, waitTime, startDelay } = this.props;
+    const { specs, waitTime, startDelay, sendReport } = this.props;
     const testSuites = [];
     // Iterate over each suite of specs and create a new TestScope for each.
     for (var i = 0; i < specs.length; i++) {
@@ -69,7 +69,7 @@ export default class Tester extends Component {
       testSuites.push(scope);
     }
     // Instantiate the test runner, pass in the array of suites and run the tests.
-    const runner = new TestRunner(this, testSuites, startDelay);
+    const runner = new TestRunner(this, testSuites, startDelay, sendReport);
     runner.run();
   }
 
@@ -102,7 +102,9 @@ Tester.propTypes = {
   specs: PropTypes.arrayOf(PropTypes.func),
   waitTime: PropTypes.number,
   startDelay: PropTypes.number,
-  clearAsyncStorage: PropTypes.bool
+  clearAsyncStorage: PropTypes.bool,
+  // Deprecated (see note in TestRunner component).
+  sendReport: PropTypes.bool
 };
 
 Tester.defaultProps = {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,39 @@
+// cavy-cli reporter function.
+
+// Internal: Check that cavy-cli server is running and if so, send report.
+export default async function(report) {
+  const url = 'http://127.0.0.1:8082/';
+
+  try {
+    const response = await fetch(url);
+    const text = await response.text();
+
+    if (text == 'cavy-cli running') {
+      return send(report);
+    } else {
+      throw new Error('Unexpected response');
+    }
+  } catch (e) {
+    console.log(`Skipping sending test report to cavy-cli - ${e.message}.`)
+  }
+}
+
+// Internal: Make a post request to the cavy-cli server with the test report.
+async function send(report) {
+  const url = 'http://127.0.0.1:8082/report';
+
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(report),
+    headers: { 'Content-Type': 'application/json' }
+  };
+
+  try {
+    await fetch(url, options);
+    console.log('Cavy test report successfully sent to cavy-cli');
+  } catch (e) {
+    console.group('Error sending test results')
+    console.warn(e.message);
+    console.groupEnd();
+  }
+}


### PR DESCRIPTION
**Includes**
- Checking whether `cavy-cli` is running before sending test report (GET /)
  - If ok response received -> attempt to send test report
  - If no response received -> console log error, don't send report
  - If unexpected response received -> console log error, don't send report
- Deprecating the `sendReport` prop, but preserving behaviour for backwards compatibility
- Updating the README and sample app to not use `sendReport`

**Notes**
- This depends on https://github.com/pixielabs/cavy-cli/pull/11

**Compatibility** - MINOR update
- Preserves behaviour of `sendProp`, but warns the user that it is deprecated
