### PR TITLE
Separate cavy-cli reporter

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -68,13 +68,6 @@ export default class TestRunner {
       duration: duration
     }
 
-    // Compile the report object.
-    const report = {
-      results: this.testResults,
-      errorCount: this.errorCount,
-      duration: duration
-    }
-
     // Send report to reporter (default is cavy-cli)
     await this.sendReport(report);
   }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -15,7 +15,7 @@ export default class TestRunner {
     this.component = component;
     this.testSuites = testSuites;
     this.startDelay = startDelay;
-    this.sendReport = reporter;
+    this.reporter = reporter;
     // Using the sendReport prop is deprecated - cavy checks whether the
     // cavy-cli server is listening and sends a report if true.
     this.shouldSendReport = sendReport;
@@ -69,7 +69,7 @@ export default class TestRunner {
     }
 
     // Send report to reporter (default is cavy-cli)
-    await this.sendReport(report);
+    await this.reporter(report);
   }
 
   // Internal: Synchronously runs each test case within a test suite, outputting

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -53,6 +53,9 @@ export default class Tester extends Component {
       key: Math.random()
     };
     this.testHookStore = props.store;
+    // Default to sending a test report to cavy-cli if no custom reporter is
+    // supplied.
+    this.reporter = props.reporter || reporter;
   }
 
   componentDidMount() {
@@ -69,8 +72,9 @@ export default class Tester extends Component {
       await specs[i](scope);
       testSuites.push(scope);
     }
+
     // Instantiate the test runner, pass in the array of suites and run the tests.
-    const runner = new TestRunner(this, testSuites, startDelay, reporter, sendReport);
+    const runner = new TestRunner(this, testSuites, startDelay, this.reporter, sendReport);
     runner.run();
   }
 
@@ -104,6 +108,7 @@ Tester.propTypes = {
   waitTime: PropTypes.number,
   startDelay: PropTypes.number,
   clearAsyncStorage: PropTypes.bool,
+  reporter: PropTypes.func,
   // Deprecated (see note in TestRunner component).
   sendReport: PropTypes.bool
 };

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -5,6 +5,7 @@ import { AsyncStorage } from 'react-native';
 import TestHookStore from './TestHookStore';
 import TestScope from './TestScope';
 import TestRunner from './TestRunner';
+import reporter from './reporter';
 
 // Public: Wrap your entire app in Tester to run tests against that app,
 // interacting with registered components in your test cases via the Cavy
@@ -69,7 +70,7 @@ export default class Tester extends Component {
       testSuites.push(scope);
     }
     // Instantiate the test runner, pass in the array of suites and run the tests.
-    const runner = new TestRunner(this, testSuites, startDelay, sendReport);
+    const runner = new TestRunner(this, testSuites, startDelay, reporter, sendReport);
     runner.run();
   }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -32,14 +32,8 @@ async function send(report) {
     await fetch(url, options);
     console.log('Cavy test report successfully sent to cavy-cli');
   } catch (e) {
-    if (e.message.match(/Network request failed/)) {
-      console.group(`Cavy test report server is not running at ${url}`);
-      console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
-      console.groupEnd();
-    } else {
-      console.group('Error sending test results')
-      console.warn(error.message);
-      console.groupEnd();
-    }
+    console.group('Error sending test results')
+    console.warn(e.message);
+    console.groupEnd();
   }
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -2,9 +2,6 @@
 
 // Internal: Check that cavy-cli server is running and if so, send report.
 export default async function(report) {
-  console.log('in here');
-  console.log(report);
-
   const url = 'http://127.0.0.1:8082/';
 
   try {
@@ -23,9 +20,6 @@ export default async function(report) {
 
 // Internal: Make a post request to the cavy-cli server with the test report.
 async function send(report) {
-  console.log('in send');
-  console.log(report);
-
   const url = 'http://127.0.0.1:8082/report';
 
   const options = {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,51 @@
+// cavy-cli reporter function.
+
+// Internal: Check that cavy-cli server is running and if so, send report.
+export default async function(report) {
+  console.log('in here');
+  console.log(report);
+
+  const url = 'http://127.0.0.1:8082/';
+
+  try {
+    const response = await fetch(url);
+    const text = await response.text();
+
+    if (text == 'cavy-cli running') {
+      return send(report);
+    } else {
+      throw new Error('Unexpected response');
+    }
+  } catch (e) {
+    console.log(`Skipping sending test report to cavy-cli - ${e.message}.`)
+  }
+}
+
+// Internal: Make a post request to the cavy-cli server with the test report.
+async function send(report) {
+  console.log('in send');
+  console.log(report);
+
+  const url = 'http://127.0.0.1:8082/report';
+
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(report),
+    headers: { 'Content-Type': 'application/json' }
+  };
+
+  try {
+    await fetch(url, options);
+    console.log('Cavy test report successfully sent to cavy-cli');
+  } catch (e) {
+    if (e.message.match(/Network request failed/)) {
+      console.group(`Cavy test report server is not running at ${url}`);
+      console.log("If you are using cavy-cli, maybe it's not set up correctly or not reachable from this device?");
+      console.groupEnd();
+    } else {
+      console.group('Error sending test results')
+      console.warn(error.message);
+      console.groupEnd();
+    }
+  }
+}


### PR DESCRIPTION
**Includes**
- Refactoring cavy-cli into a reporter function (this has the side benefit of resembling the custom reporters we are soon going to allow users to pass in)
- Allow custom reporter function to be passed into tester component and used (if defined) instead of cavy-cli