### PR TITLE
Support for React.createRef

### DIFF
--- a/sample-app/CavyDirectory/app/SearchBar.js
+++ b/sample-app/CavyDirectory/app/SearchBar.js
@@ -9,6 +9,7 @@ class SearchBar extends Component {
     this.state = {
       value: ''
     }
+    this.textInput = React.createRef();
   }
 
   _onChangeText(value) {
@@ -20,7 +21,7 @@ class SearchBar extends Component {
     return (
       <View style={styles.container}>
         <TextInput
-          ref={this.props.generateTestHook('SearchBar.TextInput')}
+          ref={this.props.generateTestHook('SearchBar.TextInput', this.textInput)}
           style={styles.input}
           placeholder="Search"
           onChangeText={(value) => this._onChangeText(value)}

--- a/src/generateTestHook.js
+++ b/src/generateTestHook.js
@@ -13,20 +13,26 @@ export default function(testHookStore) {
   //              test hook store.
   // f          - Your own ref generating function (optional).
   //
-  return function generateTestHook(identifier, f = () => {}) {
+  return function generateTestHook(identifier, ref) {
     // Returns the component, preserving any user's own ref generating function
-    // f(). Adds the component to the testHookStore if defined.
+    // f() or ref attribute created via React.createRef.
+    // Adds the component to the testHookStore if defined.
     return (component) => {
-      if (!testHookStore) {
-        f(component);
-        return
-      }
+      if (!testHookStore) return preservedRef(ref);
+
       if (component) {
         testHookStore.add(identifier, component);
       } else {
         testHookStore.remove(identifier, component);
       }
-      f(component);
+
+      return preservedRef(ref);
     }
+  }
+
+  // Either calls the ref generating function or returns the ref attribute.
+  function preservedRef(ref) {
+    if (typeof ref == 'function') return ref(component);
+    return ref;
   }
 };


### PR DESCRIPTION
**Current functionality**
- Cavy has always supported people still using in their own refs.
- `generateTestHook` takes a ref as a second argument and preserves this functionality.
- However, with React 16.3, the most common way to create refs is now via `React.createRef` - [see docs](https://reactjs.org/docs/refs-and-the-dom.html). Cavy does not support passing in this attribute type ref, only a callback.

**New functionality**
- `generateTestHook` handles both a callback ref and a ref attribute created via `React.createRef`.

**Related PRs**:
- [Updates to docs](https://github.com/pixielabs/cavy-app/pull/3)
- Updates to types/cavy for Typescript support (TODO!)