### PR TITLE
expose prop values on function ref through props property

### DIFF
--- a/sample-app/CavyDirectory/app/ButtonTester.js
+++ b/sample-app/CavyDirectory/app/ButtonTester.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import { useCavy, wrap } from 'cavy';
+
+class ClassButton extends React.Component {
+  render() {
+    const { title, onPress } = this.props;
+    return <Button title={title} onPress={onPress} />;
+  }
+}
+const FunctionButtonCore = ({ onPress, title }) => (
+  <Button title={title} onPress={onPress} />
+);
+
+const FunctionButton = wrap(FunctionButtonCore);
+
+const ButtonTester = () => {
+  const [classButtonOn, setClassButtonOn] = useState(false);
+  const [functionButtonOn, setFunctionButtonOn] = useState(false);
+
+  const generateTestHook = useCavy();
+
+  return (
+    <View>
+      {/* Class implementation */}
+      <ClassButton
+        ref={generateTestHook('ClassButton')}
+        title={`Class Button is ${classButtonOn ? 'on' : 'off'}`}
+        onPress={() => setClassButtonOn(!classButtonOn)}
+      />
+      {classButtonOn && (
+        <Text ref={generateTestHook('ClassText')}>Class Button is on</Text>
+      )}
+
+      {/* Function implementation */}
+      <FunctionButton
+        ref={generateTestHook('FunctionButton')}
+        title={`Function Button is ${functionButtonOn ? 'on' : 'off'}`}
+        onPress={() => setFunctionButtonOn(!functionButtonOn)}
+      />
+      {functionButtonOn && (
+        <Text ref={generateTestHook('FunctionText')}>
+          Function Button is on
+        </Text>
+      )}
+    </View>
+  );
+};
+
+export default ButtonTester;

--- a/sample-app/CavyDirectory/app/EmployeeDetails.js
+++ b/sample-app/CavyDirectory/app/EmployeeDetails.js
@@ -3,6 +3,7 @@ import { View, FlatList, Text, Image, StyleSheet, TouchableOpacity } from 'react
 import ActionBar from './ActionBar';
 import EmployeeListItem from './EmployeeListItem';
 import * as employeeService from './services/employee-service-mock';
+import ButtonTester from './ButtonTester';
 
 export default class EmployeeDetails extends Component {
 
@@ -65,6 +66,7 @@ export default class EmployeeDetails extends Component {
             <ActionBar mobilePhone={employee.mobilePhone} email={employee.email} />
           </View>
           {directReports}
+          <ButtonTester />
         </View>
       );
     } else {

--- a/sample-app/CavyDirectory/specs/EmployeeListSpec.js
+++ b/sample-app/CavyDirectory/specs/EmployeeListSpec.js
@@ -1,24 +1,39 @@
 export default function(spec) {
-  
   spec.describe('Listing the employees', function() {
-
     spec.it('filters the list by search input', async function() {
       await spec.exists('EmployeeList.JimCavy');
       await spec.fillIn('SearchBar.TextInput', 'Amy');
       await spec.notExists('EmployeeList.JimCavy');
       await spec.exists('EmployeeList.AmyTaylor');
     });
-
   });
 
   spec.describe('Tapping on an employee', function() {
-
     spec.it('shows a button to email them', async function() {
       await spec.fillIn('SearchBar.TextInput', 'Amy');
       await spec.press('EmployeeList.AmyTaylor');
       await spec.pause(1000);
       await spec.exists('ActionBar.EmailButton');
     });
+  });
 
+  spec.describe('Pressing a button triggers onPress', () => {
+    spec.it('when button is defined as a class', async function() {
+      await spec.fillIn('SearchBar.TextInput', 'Amy');
+      await spec.press('EmployeeList.AmyTaylor');
+      await spec.pause(1000);
+      await spec.notExists('ClassText');
+      await spec.press('ClassButton');
+      await spec.exists('ClassText');
+    });
+
+    spec.it('when button is defined as a function', async function() {
+      await spec.fillIn('SearchBar.TextInput', 'Amy');
+      await spec.press('EmployeeList.AmyTaylor');
+      await spec.pause(1000);
+      await spec.notExists('FunctionText');
+      await spec.press('FunctionButton');
+      await spec.exists('FunctionText');
+    });
   });
 }

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -35,7 +35,7 @@ export default function wrap(functionComponent) {
   return forwardRef((props, ref) => {
     // It returns the wrapped component after calling `useImperativeHandle`, so
     // that our ref can be used to call the inner function component's props.
-    useImperativeHandle(ref, () => props);
+    useImperativeHandle(ref, () => ({ props }));
     return functionComponent(props);
   });
 }


### PR DESCRIPTION
When attempting to run `spec.press()` on a function component wrapped in `Cavy.wrap`, I received the following error:

`undefined is not an object (evaluating 'component.props.onPress')`

This is because `wrap` previously flattened the wrapped component's `props` over the component instance instead of on `component.props`.

This updates the `useImperativeHandle` hook callback so that a `props` property is added to the instance, similar to the class component.

This more closely emulates a class ref and changes are not necessary to TestSpec.press. 

This is a breaking change, however, if users are manually working around this issue by calling the `onPress` handler or other prop after fetching components from the test store directly. Happy to work in a deprecation path if that's necessary.

Issue reproduction (highlighting class vs function): [repro diff](https://github.com/pixielabs/cavy/compare/master...FLGMwt:demonstrate-wrapped-function-ref-issue), [repro branch](https://github.com/FLGMwt/cavy/tree/demonstrate-wrapped-function-ref-issue)