### PR TITLE
Extend `wrap` functionality to non-function components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,11 +415,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -1671,26 +1666,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1858,14 +1838,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
       "integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "errno": {
       "version": "0.1.7",
@@ -2071,20 +2043,6 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
       }
     },
     "filename-regex": {
@@ -2919,6 +2877,14 @@
         }
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2959,6 +2925,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -3162,7 +3129,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3207,15 +3175,6 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
-      }
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -4395,15 +4354,6 @@
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4794,14 +4744,6 @@
       "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -5155,7 +5097,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "2.5.2",
@@ -5496,11 +5439,6 @@
           }
         }
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5977,11 +5915,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-    },
     "uglify-js": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
@@ -6172,11 +6105,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-url": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/pixielabs/cavy#readme",
   "dependencies": {
-    "create-react-class": "^15.6.0",
+    "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {

--- a/sample-app/CavyDirectory/app/EmployeeListItem.js
+++ b/sample-app/CavyDirectory/app/EmployeeListItem.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import { View, Text, Image, TouchableHighlight, StyleSheet } from 'react-native';
 
-import { useCavy } from 'cavy';
+import { useCavy, wrap } from 'cavy';
 
 export default ({ data, navigation }) => {
   const generateTestHook = useCavy();
-  
+  const WrappedText = wrap(Text);
+
   return (
     <TouchableHighlight
       ref={generateTestHook(`${navigation.state.routeName}.${data.firstName}${data.lastName}`)}
@@ -15,7 +16,12 @@ export default ({ data, navigation }) => {
         <Image source={{uri: data.picture}} style={styles.picture} />
         <View>
           <Text>{data.firstName} {data.lastName}</Text>
-          <Text style={styles.title}>{data.title}</Text>
+          <WrappedText
+            ref={generateTestHook(`${navigation.state.routeName}.${data.title}`)}
+            style={styles.title}
+          >
+            {data.title}
+          </WrappedText>
         </View>
       </View>
     </TouchableHighlight>

--- a/sample-app/CavyDirectory/specs/EmployeeListSpec.js
+++ b/sample-app/CavyDirectory/specs/EmployeeListSpec.js
@@ -36,4 +36,10 @@ export default function(spec) {
       await spec.exists('FunctionText');
     });
   });
+
+  spec.describe('Using wrap on Text', async function() {
+    spec.it('works', async function() {
+      await spec.containsText('EmployeeList.CEO', 'CEO');
+    });
+  });
 }

--- a/sample-app/CavyDirectory/specs/EmployeeListSpec.js
+++ b/sample-app/CavyDirectory/specs/EmployeeListSpec.js
@@ -1,3 +1,5 @@
+import { hasButtonText } from './helpers';
+
 export default function(spec) {
   spec.describe('Listing the employees', function() {
     spec.it('filters the list by search input', async function() {
@@ -14,6 +16,8 @@ export default function(spec) {
       await spec.press('EmployeeList.AmyTaylor');
       await spec.pause(1000);
       await spec.exists('ActionBar.EmailButton');
+      const button = await spec.findComponent('ActionBar.EmailButton');
+      await hasButtonText(button, 'email');
     });
   });
 

--- a/sample-app/CavyDirectory/specs/helpers.js
+++ b/sample-app/CavyDirectory/specs/helpers.js
@@ -1,0 +1,6 @@
+export async function hasButtonText(button, expected) {
+  const actual = button.props.text;
+  if (actual != expected) {
+    throw new Error(`Button text is ${actual}, not ${expected}`);
+  }
+}

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -160,6 +160,9 @@ export default class TestScope {
   // test for your maximum wait time.
   //
   // identifier - Identifier for the component.
+  //
+  // Returns a promise, use await when calling this function. Promise will be
+  // rejected if the component is not found.
   async notExists(identifier) {
     try {
       await this.findComponent(identifier);
@@ -172,6 +175,14 @@ export default class TestScope {
     throw new Error(`Component with identifier ${identifier} was present`);
   }
 
+  // Public: Checks whether a component e.g. <Text> contains the text string
+  // as a child.
+  //
+  // identifier - Identifier for the component.
+  // text - String
+  //
+  // Returns a promise, use await when calling this function. Promise will be
+  // rejected if the component is not found.
   async containsText(identifier, text) {
     const component = await this.findComponent(identifier);
 
@@ -179,5 +190,4 @@ export default class TestScope {
       throw new Error(`Could not find text ${text}`);
     };
   }
-
 }

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -171,4 +171,13 @@ export default class TestScope {
     }
     throw new Error(`Component with identifier ${identifier} was present`);
   }
+
+  async containsText(identifier, text) {
+    const component = await this.findComponent(identifier);
+
+    if (!component.props.children.includes(text)) {
+      throw new Error(`Could not find text ${text}`);
+    };
+  }
+
 }

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,6 +1,9 @@
+import React from 'react';
 import { useImperativeHandle, forwardRef } from 'react';
 
-// Higher-order component that wraps a function component in `forwardRef()`
+// With a Function Component:
+//
+// Higher-order component that wraps a Function Component in `forwardRef()`
 // and uses `useImperativeHandle` to make the properties of that component
 // available via the component ref so that Cavy can interact directly with it
 // via the testHookStore.
@@ -11,31 +14,78 @@ import { useImperativeHandle, forwardRef } from 'react';
 // More information on `useImperativeHandle`:
 // <https://reactjs.org/docs/hooks-reference.html#useimperativehandle>
 //
-// functionComponent - The function component you want to test.
-//
 // Example
 //
-//   import { Button } from 'react-native-elements';
-//   import { hook, wrap } from 'cavy';
+// import React from 'react';
+// import { Button } from 'react-native-elements';
+// import { useCavy, wrap } from 'cavy';
 //
-//   class MyComponent extends React.Component {
-//     // ...
-//     render() {
-//       const WrappedButton = wrap(Button);
+// export default () => {
+//   const generateTestHook = useCavy();
+//   const TestableButton = wrap(Button);
 //
-//       return (
-//         <WrappedButton ref={this.generateTestHook('button')} onPress={}/>
-//       )
-//     }
-//   }
-//   export default hook(MyComponent);
+//   return (
+//     <TestableButton ref={this.generateTestHook('button')} onPress={}/>
+//   )
+// };
 //
-export default function wrap(functionComponent) {
-  // `forwardRef` accepts a render function that receives our props and ref.
-  return forwardRef((props, ref) => {
-    // It returns the wrapped component after calling `useImperativeHandle`, so
-    // that our ref can be used to call the inner function component's props.
-    useImperativeHandle(ref, () => ({ props }));
-    return functionComponent(props);
-  });
+//
+//
+// With a component like `Text`:
+//
+// Higher-order component that wraps a component like `Text`, which is neither
+// a React Class nor a Function Component, and returns a React Class with
+// testable props.
+//
+// Example:
+//
+// import React from 'react';
+// import { View, Text } from 'react-native';
+// import { useCavy, wrap } from 'cavy';
+//
+// export default ({ data }) => {
+//   const generateTestHook = useCavy();
+//   const TestableText = wrap(Text);
+//
+//   return (
+//     <View>
+//       <TestableText ref={generateTestHook('title')}>
+//         {data.title}
+//       </TestableText>
+//     </View>
+//   )
+// };
+//
+export default function wrap(Component) {
+  if (typeof Component === 'function' && isNotReactClass(Component)) {
+    // `forwardRef` accepts a render function that receives our props and ref.
+    return forwardRef((props, ref) => {
+      // It returns the wrapped component after calling `useImperativeHandle`, so
+      // that our ref can be used to call the inner function component's props.
+      useImperativeHandle(ref, () => ({ props }));
+      return Component(props);
+    });
+  }
+
+  if (typeof Component == 'object') {
+    return class extends React.Component {
+      render() {
+        return <Component {...this.props} />
+      }
+    }
+  }
+
+  const message = "Looks like you're passing a class component into `wrap` - " +
+  "you don't need to do this. Attach a Cavy ref to the component itself."
+
+  console.warn(message);
+  return Component;
+}
+
+// React Class components are also functions, so we need to perform some extra
+// checks here. This code is taken from examples in React source code e.g:
+//
+// https://github.com/facebook/react/blob/12be8938a5d71ffdc21ee7cf770bf1cb63ae038e/packages/react-refresh/src/ReactFreshRuntime.js#L138
+function isNotReactClass(Component) {
+  return !(Component.prototype && Component.prototype.isReactComponent);
 }

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -68,11 +68,14 @@ export default function wrap(Component) {
   }
 
   if (typeof Component == 'object') {
-    return class extends React.Component {
+    class WrapperComponent extends React.Component {
       render() {
         return <Component {...this.props} />
       }
     }
+    // Wrap the display name for easy debugging.
+    WrapperComponent.displayName = `Wrap(${getDisplayName(Component)})`;
+    return WrapperComponent;
   }
 
   const message = "Looks like you're passing a class component into `wrap` - " +
@@ -88,4 +91,8 @@ export default function wrap(Component) {
 // https://github.com/facebook/react/blob/12be8938a5d71ffdc21ee7cf770bf1cb63ae038e/packages/react-refresh/src/ReactFreshRuntime.js#L138
 function isNotReactClass(Component) {
   return !(Component.prototype && Component.prototype.isReactComponent);
+}
+
+function getDisplayName(Component) {
+  return Component.displayName || Component.name || 'Component';
 }

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useImperativeHandle, forwardRef } from 'react';
+import React, { useImperativeHandle, forwardRef } from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 // With a Function Component:
 //
@@ -33,8 +33,8 @@ import { useImperativeHandle, forwardRef } from 'react';
 //
 // With a component like `Text`:
 //
-// Higher-order component that wraps a component like `Text`, which is neither
-// a React Class nor a Function Component, and returns a React Class with
+// Higher-order component that wraps a native component like `Text`, (neither
+// a React Class nor a Function Component), and returns a React Class with
 // testable props.
 //
 // Example:
@@ -67,12 +67,19 @@ export default function wrap(Component) {
     });
   }
 
+  // For native components like <Text>, the RN component itself is a plain
+  // object, not a function. For these components, the RN renderer returns
+  // an instance of `ReactNativeFiberHostComponent`, which does not expose any
+  // props. Users should wrap these components - here we're wrapping them and
+  // in a class component and exposing testable props.
   if (typeof Component == 'object') {
     class WrapperComponent extends React.Component {
       render() {
         return <Component {...this.props} />
       }
     }
+    // Copy all non-React static methods.
+    hoistNonReactStatics(WrapperComponent, Component);
     // Wrap the display name for easy debugging.
     WrapperComponent.displayName = `Wrap(${getDisplayName(Component)})`;
     return WrapperComponent;


### PR DESCRIPTION
This addresses issue #101. Please see comments on the thread for a more in depth discussion of the changes being made.

**Currently** 
For elements like `Text`,  the React Native renderer returns an instance of a `ReactNativeFiberHostComponent`. This is what is passed to the ref callback; none of the original props are exposed.

Therefore, if you pass a Cavy ref to a `Text` component, anything other than the presence of that element on the page is impossible to test. You cannot call any props after finding the component using `findComponent`.

**Proposed**
You can pass a `Text` component into wrap and Cavy will return a wrapped version of that component with accessible props.

If you attempt to wrap a proper class component, Cavy warns you that you do not need to do this and just returns the component.

**Thoughts**
I've also added `containsText` as a helper function to the `TestScope`, but all this does is check for `component.props.children.includes(text)`. @jalada I could change the name of this to be more generic?