### PR TITLE
Hoist statics in HOCs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2919,6 +2919,14 @@
         }
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/pixielabs/cavy#readme",
   "dependencies": {
     "create-react-class": "^15.6.0",
+    "hoist-non-react-statics": "^3.3.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import hoistNonReactStatic from 'hoist-non-react-statics';
 import PropTypes from 'prop-types';
 
 import TestHookStore from './TestHookStore';
@@ -43,7 +44,7 @@ import generateTestHook from './generateTestHook';
 //
 // Returns the new component with the ref generating function generateTestHook as a prop.
 export default function hook(WrappedComponent) {
-  const wrapperComponent = class extends Component {
+  const WrapperComponent = class extends Component {
     render() {
       const testHookStore = this.context;
       return (
@@ -54,8 +55,16 @@ export default function hook(WrappedComponent) {
       )
     }
   };
+  // Set the context type.
+  WrapperComponent.contextType = TesterContext;
+  // Copy all non-React static methods.
+  hoistNonReactStatic(WrapperComponent, WrappedComponent);
+  // Wrap the display name for easy debugging.
+  WrapperComponent.displayName = `Hook(${getDisplayName(WrappedComponent)})`
 
-  wrapperComponent.contextType = TesterContext;
+  return WrapperComponent;
+}
 
-  return wrapperComponent;
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }


### PR DESCRIPTION
This PR addresses issue #146.

- Uses `hoist-non-react-statics` in the `hook` HOC so that statics are preserved.
- Wraps the `displayName` of the wrapped component for ease of debugging as per [HOC best practices](https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over).