### PR TITLE
Upgrade containsText to handle numbers in JSX.

### DIFF
--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -201,8 +201,11 @@ export default class TestScope {
   // rejected if the component is not found.
   async containsText(identifier, text) {
     const component = await this.findComponent(identifier);
+    const stringifiedChildren = component.props.children.includes
+      ? component.props.children
+      : String(component.props.children);
 
-    if (!component.props.children.includes(text)) {
+    if (!stringifiedChildren.includes(text)) {
       throw new Error(`Could not find text ${text}`);
     }
   }


### PR DESCRIPTION
Hello Cavy team!

This PR allows the `containsText` method to check integers in JSX without throwing an error message. Previously, if a `<Text>` component was rendering a number, `containsText` would not know how to interpret the contents of the `<Text>` component because JavaScript numbers do not have the `.includes()` method.

This solution simply checks if the `component.props.children.includes` is defined. If it is, the `children` value is a string. Otherwise, the function will cast the value as a string. This fix is backwards compatible and does not change the behavior of `containsText`. 

Here is a bare bones example of the problem that this pull request would solve:

In the component file:
```
const number = 23;
...
<View>
    <Text ref={generateTestHook('NumberTextComponent')}>{number}</Text>
</View>
```

In the test file: 
```
await spec.containsText('NumberTextComponent', '23');
```
This would throw the following error: `component.props.children.includes is not a function. (In 'component.props.children.includes(text)', 'component.props.children.includes' is undefined)` because the JSX value is being stored as a number.

Without this modification, the only way to solve this problem would be to cast the value as a string within the JSX: `<Text ref={...}>{String(number)}</Text>`, which would not be sustainable for large code bases.

Thank you all for taking the time to read through this PR, and for making such a cool testing library! Please let me know if I can provide any more additional information.