### PR TITLE
Updating XCode version in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,9 @@
 version: 2
 jobs:
   ios:
-
     # Specify the Xcode version to use
     macos:
-      xcode: "9.0"
+      xcode: 10.3.0
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
           name: Install React Native dependencies
           command: |
             brew update
-            brew upgrade python
             brew install watchman || exit 0
 
       - run:


### PR DESCRIPTION
We're compiling python every time we build in CircleCI, which takes forever and a day - let's see whether this XCode update helps. It may mean that we can get rid of `brew upgrade python`.

It may also help with the Cocoapods mismatch issue in the Cavy Tester PR #147.