### PR TITLE
[FEATURE] Send in-progress test results to the CLI

### DIFF
--- a/src/Reporter.js
+++ b/src/Reporter.js
@@ -2,8 +2,8 @@
 // the CLI.
 export default class Reporter {
   constructor() {
-    // Set the Reporter type to inProgress.
-    this.type = 'inProgress';
+    // Set the Reporter type to realtime.
+    this.type = 'realtime';
   }
 
   // Internal: Creates a websocket connection to the cavy-cli server.

--- a/src/Reporter.js
+++ b/src/Reporter.js
@@ -1,26 +1,30 @@
 // Internal: CavyReporter is responsible for sending the test results to
 // the CLI.
 export default class CavyReporter {
+  constructor() {
+    // Set the Reporter type to inProgress.
+    this.type = 'inProgress';
+  }
+
   // Internal: Creates a websocket connection to the cavy-cli server.
   onStart() {
     const url = 'ws://127.0.0.1:8082/';
     this.ws = new WebSocket(url);
   }
 
+  // Internal: Send a single test result to cavy-cli over the websocket connection.
+  send(result) {
+    if (this.websocketReady()) {
+      testData = { event: 'singleResult', data: result };
+      this.sendData(testData);
+    }
+  }
+
   // Internal: Send report to cavy-cli over the websocket connection.
-  onFinish(testData) {
-    // WebSocket.readyState 1 means the web socket connection is OPEN.
-    if (this.ws.readyState == 1) {
-      try {
-        this.ws.send(JSON.stringify(testData));
-        if (testData.route == 'testingComplete') {
-          console.log('Cavy test report successfully sent to cavy-cli');
-        }
-      } catch (e) {
-        console.group('Error sending test data');
-        console.warn(e.message);
-        console.groupEnd();
-      }
+  onFinish(report) {
+    if (this.websocketReady()) {
+      testData = { event: 'testingComplete', data: report };
+      this.sendData(testData);
     } else {
       // If cavy-cli is not running, let people know in a friendly way
       const message = "Skipping sending test report to cavy-cli - if you'd " +
@@ -28,6 +32,26 @@ export default class CavyReporter {
       'https://github.com/pixielabs/cavy-cli';
 
       console.log(message);
+    }
+  }
+
+  // Private: Determines whether data can be sent over the websocket.
+  websocketReady() {
+    // WebSocket.readyState 1 means the web socket connection is OPEN.
+    return this.ws.readyState == 1;
+  }
+
+  // Private: Sends data over the websocket and console logs any errors.
+  sendData(testData) {
+    try {
+      this.ws.send(JSON.stringify(testData));
+      if (testData.event == 'testingComplete') {
+        console.log('Cavy test report successfully sent to cavy-cli');
+      }
+    } catch (e) {
+      console.group('Error sending test data');
+      console.warn(e.message);
+      console.groupEnd();
     }
   }
 }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -78,7 +78,10 @@ export default class TestRunner {
     }
 
     // Send report to reporter (default is cavy-cli)
-    await this.reporter.send(report);
+    await this.reporter.send({
+      route: 'testingComplete',
+      data: report
+    });
   }
 
   // Internal: Synchronously runs each test case within a test suite, outputting
@@ -119,6 +122,11 @@ export default class TestRunner {
         time: time
       });
 
+      this.reporter.send({
+        route: 'singleResult',
+        data: { message: successMsg, passed: true }
+      });
+
     } catch (e) {
       const stop = new Date();
       const time = (stop - start) / 1000;
@@ -133,6 +141,11 @@ export default class TestRunner {
         errorMessage: e.message,
         passed: false,
         time: time
+      });
+
+      this.reporter.send({
+        route: 'singleResult',
+        data: { message: fullErrorMessage, passed: false }
       });
 
       // Increase error count for reporting.

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -80,9 +80,9 @@ export default class TestRunner {
     // Send report to reporter (default is cavy-cli)
     if (this.reporter instanceof Function) {
       await this.reporter(report);
-    } else if (this.reporter.type == 'inProgress') {
+    } else if (this.reporter.type == 'realtime') {
       await this.reporter.onFinish(report);
-    } else if (this.reporter.type == 'simple') {
+    } else if (this.reporter.type == 'deferred') {
       await this.reporter.send(report);
     } else {
       message = 'Could not find a valid reporter. For more ' +
@@ -131,7 +131,7 @@ export default class TestRunner {
       });
 
       if (!(this.reporter instanceof Function)
-        && this.reporter.type == 'inProgress' ) {
+        && this.reporter.type == 'realtime' ) {
         const result = { message: successMsg, passed: true };
         this.reporter.send(result);
       }
@@ -153,7 +153,7 @@ export default class TestRunner {
       });
 
       if (!(this.reporter instanceof Function)
-        && this.reporter.type == 'inProgress' ) {
+        && this.reporter.type == 'realtime' ) {
         const result = { message: fullErrorMessage, passed: false };
         this.reporter.send(result);
       }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -85,7 +85,7 @@ export default class TestRunner {
     } else if (this.reporter.type == 'simple') {
       await this.reporter.send(report);
     } else {
-      message = 'Could not find a valid custom reporter. For more ' +
+      message = 'Could not find a valid reporter. For more ' +
                 'information on custom reporters, see the documentation ' +
                 'here: https://cavy.app/docs/guides/writing-custom-reporters';
       console.log(message);

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -76,7 +76,7 @@ export default class Tester extends Component {
   componentDidMount() {
     this.runTests();
     if (!(this.reporter instanceof Function)
-      && this.reporter.type == 'inProgress' ) {
+      && this.reporter.type == 'realtime' ) {
       this.reporter.onStart();
     }
   }

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -75,7 +75,8 @@ export default class Tester extends Component {
 
   componentDidMount() {
     this.runTests();
-    if (!(this.reporter instanceof Function)) {
+    if (!(this.reporter instanceof Function)
+      && this.reporter.type == 'inProgress' ) {
       this.reporter.onStart();
     }
   }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -7,14 +7,16 @@ export default {
   },
 
   // Internal: Send report to cavy-cli over the websocket connection.
-  send: function(report) {
+  send: function(testData) {
     // WebSocket.readyState 1 means the web socket connection is OPEN.
     if (this.ws.readyState == 1) {
       try {
-        this.ws.send(JSON.stringify(report));
-        console.log('Cavy test report successfully sent to cavy-cli');
+        this.ws.send(JSON.stringify(testData));
+        if (testData.route == 'testingComplete') {
+          console.log('Cavy test report successfully sent to cavy-cli');
+        }
       } catch (e) {
-        console.group('Error sending test results');
+        console.group('Error sending test data');
         console.warn(e.message);
         console.groupEnd();
       }


### PR DESCRIPTION
[Roadmap Ticket](https://www.pivotaltracker.com/story/show/172696470)

### Includes
- send two types of message to the cli server,`singleResult` and `testingComplete`.
    - Send a `singleResult` message after every test.
    - Send a `testingComplete` message at the end of the test suite.

### Testing
To test you need use [this](https://github.com/pixielabs/cavy-cli/tree/send-in-progress-test-results) branch of Cavy CLI.
See this [PR](https://github.com/pixielabs/cavy-cli/pull/30).

### Compatibility
- This is a backwards compatible change. Propose a minor version bump