### PR TITLE
Improve error message for `containsText`

### DIFF
--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -7,6 +7,15 @@ class ComponentNotFoundError extends Error {
   }
 }
 
+// Custom error returned when a component has not been wrapped, but should have
+// been.
+class UnwrappedComponentError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UnwrappedComponentError";
+  }
+}
+
 // Internal: TestScope is responsible for building up testCases to be run by
 // the TestRunner, and includes all the functions available when writing these
 // specs.
@@ -176,9 +185,10 @@ export default class TestScope {
       const msg = "Cannot read property 'children' of undefined.\n" +
         "Are you using `containsText` with a React <Text> component?\n" +
         "If so, you need to `wrap` the component first.\n" +
-        "See documentation for Cavy's `wrap` function: https://cavy.app/docs/api/test-hooks#example-3"
+        "See documentation for Cavy's `wrap` function:" +
+        "https://cavy.app/docs/api/test-hooks#example-3";
 
-      throw new Error(msg)
+      throw new UnwrappedComponentError(msg);
     }
 
     const stringifiedChildren = component.props.children.includes

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -171,6 +171,16 @@ export default class TestScope {
   // rejected if the component is not found.
   async containsText(identifier, text) {
     const component = await this.findComponent(identifier);
+
+    if (component.props === undefined) {
+      const msg = "Cannot read property 'children' of undefined.\n" +
+        "Are you using `containsText` with a React <Text> component?\n" +
+        "If so, you need to `wrap` the component first.\n" +
+        "See documentation for Cavy's `wrap` function: https://cavy.app/docs/api/test-hooks#example-3"
+
+      throw new Error(msg)
+    }
+
     const stringifiedChildren = component.props.children.includes
       ? component.props.children
       : String(component.props.children);

--- a/test/CavyTester/src/App.js
+++ b/test/CavyTester/src/App.js
@@ -5,6 +5,7 @@ import { Tester, TestHookStore, useCavy } from 'cavy';
 
 import * as containsText from './scenarios/containsText';
 import * as containsTextNumerical from './scenarios/containsTextNumerical';
+import * as containsTextUnwrapped from './scenarios/containsTextUnwrapped';
 import * as pressClassComponent from './scenarios/pressClassComponent';
 import * as pressFunctionComponent from './scenarios/pressFunctionComponent';
 import * as exists from './scenarios/exists';
@@ -18,6 +19,7 @@ import * as notExists from './scenarios/notExists';
 const scenarios = [
   containsText,
   containsTextNumerical,
+  containsTextUnwrapped,
   pressClassComponent,
   pressFunctionComponent,
   exists,

--- a/test/CavyTester/src/scenarios/containsTextUnwrapped.js
+++ b/test/CavyTester/src/scenarios/containsTextUnwrapped.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { useCavy } from 'cavy';
+
+export const key = 'ContainsTextUnwrapped';
+
+const testId = `${key}.Element`;
+const text = 'I am text';
+
+export const Screen = () => {
+  const generateTestHook = useCavy();
+  return <Text ref={generateTestHook(testId)}>{text}</Text>
+};
+
+export const label = 'spec.containsText raises a nice error if used on unwrapped <Text>';
+export const spec = spec =>
+  spec.describe(key, () =>
+    spec.it(label, async () => {
+      try {
+        await spec.containsText(testId, text);  
+      } catch (error) {
+        if (error.name === 'UnwrappedComponentError') return;
+        throw error;
+      }
+    })
+  );


### PR DESCRIPTION
[Roadmap ticket](https://www.pivotaltracker.com/story/show/172913765)

If you're using `containsText`, it's quite likely that you're using it on a React `<Text>` component.

Unfortunately, you have to `wrap` a `<Text>` component to make it testable in this way.

When writing the test for the new Cavy Tester app, even I fell into this trap! We've also had a number of users raise this issue before - "why isn't this working on Text?".

I've made `containsText` raise a new Error that gives more guidance on what you might need to do to fix your test.

**Please when reviewing give your opinions on:**
1. the error name
2. the error message

as I went through multiple iterations when writing.