### PR TITLE
[FEATURE] Ability to tag and filter tests

### DIFF
--- a/src/TestHookStore.js
+++ b/src/TestHookStore.js
@@ -35,5 +35,4 @@ export default class TestHookStore {
   get(identifier) {
     return this.hooks[identifier];
   }
-
 }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -37,14 +37,30 @@ export default class TestRunner {
     const start = new Date();
     console.log(`Cavy test suite started at ${start}.`);
 
+    // Setup collections for tests
+    const focusedTests = [];
+    const allTests = [];
+
     // Iterate through each suite...
     for (let i = 0; i < this.testSuites.length; i++) {
       // And then through the suite's test cases...
       for (let j = 0; j < this.testSuites[i].testCases.length; j++) {
         let scope = this.testSuites[i];
-        // And run each test, within the test scope.
-        await this.runTest(scope, scope.testCases[j]);
+        // If the test has a 'focus' flag...
+        if (scope.testCases[j].focus == 'focus') {
+          // Add the test scope and the test to the focusedTests array...
+          focusedTests.push({ scope, testCase: scope.testCases[j] });
+        }
+        // Add the test scope and the test to the allTests array...
+        allTests.push({ scope, testCase: scope.testCases[j] });
       }
+    }
+
+    // If there are any focused tests, only run them, otherwise run all the tests
+    const tests = focusedTests.length ? focusedTests : allTests;
+    for (let i = 0; i < tests.length; i++) {
+      const { scope, testCase } = tests[i];
+      await this.runTest(scope, testCase);
     }
 
     const stop = new Date();

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -47,7 +47,7 @@ export default class TestRunner {
       for (let j = 0; j < this.testSuites[i].testCases.length; j++) {
         let scope = this.testSuites[i];
         // If the test has a 'focus' flag...
-        if (scope.testCases[j].focus == 'focus') {
+        if (scope.testCases[j].focus) {
           // Add the test scope and the test to the focusedTests array...
           focusedTests.push({ scope, testCase: scope.testCases[j] });
         }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -13,7 +13,7 @@
 //              all tests have finished.
 //
 export default class TestRunner {
-  constructor(component, testSuites, startDelay, reporter, sendReport) {
+  constructor(component, testSuites, startDelay, reporter, sendReport, filter) {
     this.component = component;
     this.testSuites = testSuites;
     this.startDelay = startDelay;
@@ -21,6 +21,9 @@ export default class TestRunner {
     // Using the sendReport prop is deprecated - cavy checks whether the
     // cavy-cli server is listening and sends a report if true.
     this.shouldSendReport = sendReport;
+    // An array of strings dictating the subset of tagged tests to run, or null
+    // if all tests should be run.
+    this.filter = filter;
     this.results = [];
     this.errorCount = 0;
   }
@@ -36,18 +39,17 @@ export default class TestRunner {
   async runTestSuites() {
     const start = new Date();
     console.log(`Cavy test suite started at ${start}.`);
-    
-    const focused = this.testSuites.some(s => s.testCases.some(c => c.focus));
 
     // Iterate through each suite...
     for (let i = 0; i < this.testSuites.length; i++) {
       // And then through the suite's test cases...
       for (let j = 0; j < this.testSuites[i].testCases.length; j++) {
         let scope = this.testSuites[i];
+        let tag = scope.testCases[j].tag;
         // Run the test if:
-        // 1. The test suite isn't focused
-        // 2. The test suite is focused and the test itself is focused
-        if (!focused || (focused && scope.testCases[j].focus)) {
+        // 1. The test suite isn't filtered
+        // 2. The test suite is filtered and test's tag is included
+        if (!this.filter || (this.filter && this.filter.includes(tag))) {
           await this.runTest(scope, scope.testCases[j]);
         };
       }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -36,31 +36,21 @@ export default class TestRunner {
   async runTestSuites() {
     const start = new Date();
     console.log(`Cavy test suite started at ${start}.`);
-
-    // Setup collections for tests
-    const focusedTests = [];
-    const allTests = [];
+    
+    const focused = this.testSuites.some(s => s.testCases.some(c => c.focus));
 
     // Iterate through each suite...
     for (let i = 0; i < this.testSuites.length; i++) {
       // And then through the suite's test cases...
       for (let j = 0; j < this.testSuites[i].testCases.length; j++) {
         let scope = this.testSuites[i];
-        // If the test has a 'focus' flag...
-        if (scope.testCases[j].focus) {
-          // Add the test scope and the test to the focusedTests array...
-          focusedTests.push({ scope, testCase: scope.testCases[j] });
-        }
-        // Add the test scope and the test to the allTests array...
-        allTests.push({ scope, testCase: scope.testCases[j] });
+        // Run the test if:
+        // 1. The test suite isn't focused
+        // 2. The test suite is focused and the test itself is focused
+        if (!focused || (focused && scope.testCases[j].focus)) {
+          await this.runTest(scope, scope.testCases[j]);
+        };
       }
-    }
-
-    // If there are any focused tests, only run them, otherwise run all the tests
-    const tests = focusedTests.length ? focusedTests : allTests;
-    for (let i = 0; i < tests.length; i++) {
-      const { scope, testCase } = tests[i];
-      await this.runTest(scope, testCase);
     }
 
     const stop = new Date();

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -102,10 +102,12 @@ export default class TestScope {
   // label - Label for this test case. This is combined with the label from
   //         `describe` when Cavy outputs to the console.
   // f     - The test case.
+  // focus - (Optional) A test flag which causes Cavy to ignore all
+  //         unflagged tests.
   //
   // See example above.
-  it(label, f) {
-    this.testCases.push({ describeLabel: this.describeLabel, label, f });
+  it(label, f, focus = null) {
+    this.testCases.push({ describeLabel: this.describeLabel, label, f, focus });
   }
 
   // Public: Runs a function before each test case.

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -107,6 +107,14 @@ export default class TestScope {
   //
   // See example above.
   it(label, f, focus = null) {
+    if (focus && focus != 'focus'){
+      message  = 'An additional argument was passed to `.it()` in test ' +
+                 `'${this.describeLabel}: ${label}'.\nIf you intended to ` +
+                 "focus Cavy on this test, the additional argument must be " +
+                 "the string, 'focus'. See the documentation here: " +
+                 "https://cavy.app/docs/api/helpers#itlabel-function"
+      console.warn(message)
+    }
     this.testCases.push({ describeLabel: this.describeLabel, label, f, focus });
   }
 

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -16,15 +16,6 @@ class UnwrappedComponentError extends Error {
   }
 }
 
-// Custom error returned when the `.it()` method receives a focus argument,
-// that is not the string 'focus'.
-class FocusArgumentError extends Error {
-  constructor(message) {
-    super(message);
-    this.name =  "FocusArgumentError";
-  }
-}
-
 // Internal: TestScope is responsible for building up testCases to be run by
 // the TestRunner, and includes all the functions available when writing these
 // specs.

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -16,6 +16,15 @@ class UnwrappedComponentError extends Error {
   }
 }
 
+// Custom error returned when the `.it()` method receives a focus argument,
+// that is not the string 'focus'.
+class FocusArgumentError extends Error {
+  constructor(message) {
+    super(message);
+    this.name =  "FocusArgumentError";
+  }
+}
+
 // Internal: TestScope is responsible for building up testCases to be run by
 // the TestRunner, and includes all the functions available when writing these
 // specs.
@@ -113,7 +122,7 @@ export default class TestScope {
                  "focus Cavy on this test, the additional argument must be " +
                  "the string, 'focus'. See the documentation here: " +
                  "https://cavy.app/docs/api/helpers#itlabel-function"
-      console.warn(message)
+      throw new FocusArgumentError(message);
     }
     this.testCases.push({
       describeLabel: this.describeLabel,

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -77,35 +77,39 @@ export default class TestScope {
   //
   // label - Label for these test cases.
   // f     - Callback function containing your tests cases defined with `it`.
+  // tag   - (Optional) A string tag used to determine whether the group of
+  //          tests should run. Defaults to null.
   //
   // Example
   //
   //   // specs/MyFeatureSpec.js
   //   export default function(spec) {
   //     spec.describe('My Scene', function() {
-  //
   //       spec.it('Has a component', async function() {
   //         await spec.exists('MyScene.myComponent');
-  //       });
-  //
+  //       }, 'focus');
   //     });
   //   }
   //
   // Returns undefined.
-  describe(label, f) {
+  describe(label, f, tag = null) {
     this.describeLabel = label;
+    this.tag = tag;
     f.call(this);
   }
 
   // Public: Define a test case.
   //
-  // label - Label for this test case. This is combined with the label from
+  // label   - Label for this test case. This is combined with the label from
   //         `describe` when Cavy outputs to the console.
-  // f     - The test case.
-  // tag   - (Optional) A test tag used to determine whether the test should run
+  // f       - The test case.
+  // testTag - (Optional) A string tag used to determine whether the individual
+  //           test should run. 'Inherits' a tag from its surrounding describe
+  //           block (if present) or defaults to null.
   //
   // See example above.
-  it(label, f, tag = null) {
+  it(label, f, testTag = null) {
+    const tag = this.tag || testTag;
     this.testCases.push({ describeLabel: this.describeLabel, label, f, tag });
   }
 

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -115,7 +115,11 @@ export default class TestScope {
                  "https://cavy.app/docs/api/helpers#itlabel-function"
       console.warn(message)
     }
-    this.testCases.push({ describeLabel: this.describeLabel, label, f, focus });
+    this.testCases.push({
+      describeLabel: this.describeLabel,
+      label, f,
+      focus: focus == 'focus'
+    });
   }
 
   // Public: Runs a function before each test case.

--- a/src/TestScope.js
+++ b/src/TestScope.js
@@ -111,24 +111,11 @@ export default class TestScope {
   // label - Label for this test case. This is combined with the label from
   //         `describe` when Cavy outputs to the console.
   // f     - The test case.
-  // focus - (Optional) A test flag which causes Cavy to ignore all
-  //         unflagged tests.
+  // tag   - (Optional) A test tag used to determine whether the test should run
   //
   // See example above.
-  it(label, f, focus = null) {
-    if (focus && focus != 'focus'){
-      message  = 'An additional argument was passed to `.it()` in test ' +
-                 `'${this.describeLabel}: ${label}'.\nIf you intended to ` +
-                 "focus Cavy on this test, the additional argument must be " +
-                 "the string, 'focus'. See the documentation here: " +
-                 "https://cavy.app/docs/api/helpers#itlabel-function"
-      throw new FocusArgumentError(message);
-    }
-    this.testCases.push({
-      describeLabel: this.describeLabel,
-      label, f,
-      focus: focus == 'focus'
-    });
+  it(label, f, tag = null) {
+    this.testCases.push({ describeLabel: this.describeLabel, label, f, tag });
   }
 
   // Public: Runs a function before each test case.

--- a/src/Tester.js
+++ b/src/Tester.js
@@ -68,7 +68,7 @@ export default class Tester extends Component {
 
   // Run all test suites.
   async runTests() {
-    const { specs, waitTime, startDelay, sendReport } = this.props;
+    const { specs, waitTime, startDelay, sendReport, only } = this.props;
     const testSuites = [];
     // Iterate over each suite of specs and create a new TestScope for each.
     for (var i = 0; i < specs.length; i++) {
@@ -77,8 +77,18 @@ export default class Tester extends Component {
       testSuites.push(scope);
     }
 
-    // Instantiate the test runner, pass in the array of suites and run the tests.
-    const runner = new TestRunner(this, testSuites, startDelay, this.reporter, sendReport);
+    // Instantiate the test runner with the test suites, the reporter to use,
+    // the startDelay to apply, and the `only` filter to apply.
+    const runner = new TestRunner(
+      this,
+      testSuites,
+      startDelay,
+      this.reporter,
+      sendReport,
+      only
+    );
+
+    // Run the tests.
     runner.run();
   }
 
@@ -107,18 +117,19 @@ export default class Tester extends Component {
 }
 
 Tester.propTypes = {
-  store: PropTypes.instanceOf(TestHookStore),
-  specs: PropTypes.arrayOf(PropTypes.func),
-  waitTime: PropTypes.number,
-  startDelay: PropTypes.number,
   clearAsyncStorage: PropTypes.bool,
+  only: PropTypes.arrayOf(PropTypes.string),
   reporter: PropTypes.func,
-  // Deprecated (see note in TestRunner component).
-  sendReport: PropTypes.bool
+  // Deprecated (see note in TestRunner component)
+  sendReport: PropTypes.bool,
+  specs: PropTypes.arrayOf(PropTypes.func),
+  startDelay: PropTypes.number,
+  store: PropTypes.instanceOf(TestHookStore),
+  waitTime: PropTypes.number
 };
 
 Tester.defaultProps = {
-  waitTime: 2000,
+  clearAsyncStorage: false,
   startDelay: 0,
-  clearAsyncStorage: false
+  waitTime: 2000
 };

--- a/test/CavyTester/src/App.js
+++ b/test/CavyTester/src/App.js
@@ -13,6 +13,7 @@ import * as fillIn from './scenarios/fillIn';
 import * as findComponent from './scenarios/findComponent';
 import * as focus from './scenarios/focus';
 import * as notExists from './scenarios/notExists';
+import * as taggingTest from './scenarios/taggingTest';
 // Import new scenarios here:
 
 // Add new scenarios here:
@@ -26,7 +27,8 @@ const scenarios = [
   fillIn,
   findComponent,
   focus,
-  notExists
+  notExists,
+  taggingTest
 ];
 
 // Validate scenarios.
@@ -81,6 +83,14 @@ const store = new TestHookStore();
 // scene.
 const navigateAndRun = (scenario) => {
   return (spec) => {
+    // Override `describe` so that all tests have the 'focus' tag, unless you
+    // specifically pass a different tag in.
+    const origDescribe = spec.describe;
+    spec.describe = (label, f, tag) => {
+      const testTag = tag || 'focus';
+      origDescribe.call(spec, label, f, testTag)
+    }
+
     // Override `it` so that it first presses into the scene.
     const origIt = spec.it;
     spec.it = (label, f) => {
@@ -96,7 +106,11 @@ const navigateAndRun = (scenario) => {
 
 // Wrap our app in the Tester component, containing all our test scenarios.
 const App = () => (
-  <Tester specs={scenarios.map(x => navigateAndRun(x))} store={store}>
+  <Tester
+    specs={scenarios.map(x => navigateAndRun(x))}
+    store={store}
+    only={['focus']}
+    >
     <AppContainer />
   </Tester>
 );

--- a/test/CavyTester/src/scenarios/taggingTest.js
+++ b/test/CavyTester/src/scenarios/taggingTest.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const key = 'TaggingSingleTest';
+
+export const Screen = () => {
+  return <></>;
+};
+
+export const label = 'adding a tag to an `it` block filters the test';
+export const spec = spec =>
+  spec.describe(key, () => {
+    spec.it(label, async () => {
+      throw new Error('This test should not run!');
+    })
+  }, 'dontRun');


### PR DESCRIPTION
[Roadmap ticket](https://www.pivotaltracker.com/story/show/172696435)
Issue: https://github.com/pixielabs/cavy/issues/164

This addresses the need to be able to run only a subset of tests.

**Proposed functionality**
- Users can tag their tests with a string, e.g. 'focus'
- Users can then specify which tagged tests to run by passing in a prop to their `Tester` component e.g. `only={['focus']}`
  - Multiple tags are supported, just add strings to the array
- If no `only` prop is passed into the `Tester` component, then all tests are run

**Proposed API**
In app.js, the addition of the optional `only` prop:

```js
class AppWrapper extends Component {
  render() {
    return (
      <Tester specs={[Spec]} store={testHookStore} only={['focus']}>
        <App/>
      </Tester>
    );
  }
}
```

In your spec.js, the optional second parameter can be passed to either the `it` or the `describe` block:
```js
export default function(spec) {
  spec.describe('A test', function() {
    spec.it('works', async function() {
      await spec.exists('Something');
    }, 'focus');
  });
}
```

**Note:** `it` tags that are inside an _already_ tagged `describe` block will be ignored. The `describe` block tag takes precedence and is applied to all `it` blocks.

**Compatibility**
- This is a backwards compatible change, hence propose a minor version bump