### PR TITLE
Add index.test.js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "jest": {
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/sample-app/"
+      "/sample-app/",
+      "/test/CavyTester/"
     ]
   }
 }

--- a/sample-app/CavyDirectory/index.js
+++ b/sample-app/CavyDirectory/index.js
@@ -2,27 +2,9 @@
  * @format
  */
 
-import React, { Component } from 'react';
 import {AppRegistry} from 'react-native';
 import {name as appName} from './app.json';
 
-import { Tester, TestHookStore } from 'cavy';
-
 import EmployeeDirectoryApp from './app/EmployeeDirectoryApp';
 
-import EmployeeListSpec from './specs/EmployeeListSpec';
-
-const testHookStore = new TestHookStore();
-
-class AppWrapper extends Component {
-  render() {
-    return (
-      <Tester specs={[EmployeeListSpec]} store={testHookStore} waitTime={1000}
-        startDelay={3000}>
-        <EmployeeDirectoryApp />
-      </Tester>
-    );
-  }
-}
-
-AppRegistry.registerComponent(appName, () => AppWrapper);
+AppRegistry.registerComponent(appName, () => EmployeeDirectoryApp);

--- a/sample-app/CavyDirectory/index.test.js
+++ b/sample-app/CavyDirectory/index.test.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import {AppRegistry} from 'react-native';
+import {name as appName} from './app.json';
+
+import { Tester, TestHookStore } from 'cavy';
+
+import EmployeeDirectoryApp from './app/EmployeeDirectoryApp';
+
+import EmployeeListSpec from './specs/EmployeeListSpec';
+
+const testHookStore = new TestHookStore();
+
+class AppWrapper extends Component {
+  render() {
+    return (
+      <Tester specs={[EmployeeListSpec]} store={testHookStore} waitTime={1000}
+        startDelay={3000}>
+        <EmployeeDirectoryApp />
+      </Tester>
+    );
+  }
+}
+
+AppRegistry.registerComponent(appName, () => AppWrapper);

--- a/test/CavyTester/index.test.js
+++ b/test/CavyTester/index.test.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+import scenarios from './src/scenarios';
+import { Tester, TestHookStore } from 'cavy';
+const store = new TestHookStore();
+
+// Validate scenarios.
+scenarios.forEach(scenario => {
+  if (!(scenario.key && scenario.label && scenario.Screen && scenario.spec)) {
+    throw Error(
+      'CavyTester: key, label, Screen, and spec must be defined for each scenario'
+    );
+  }
+  if (!/^[a-z0-9]+$/i.exec(scenario.key)) {
+    throw Error('CavyTester: Scenario keys should be alphanumeric');
+  }
+});
+
+// Map each of our test scenarios, so that each first navigates to the correct
+// scene.
+const navigateAndRun = (scenario) => {
+  return (spec) => {
+    // Override `describe` so that all tests have the 'focus' tag, unless you
+    // specifically pass a different tag in.
+    const origDescribe = spec.describe;
+    spec.describe = (label, f, tag) => {
+      const testTag = tag || 'focus';
+      origDescribe.call(spec, label, f, testTag)
+    }
+
+    // Override `it` so that it first presses into the scene.
+    const origIt = spec.it;
+    spec.it = (label, f) => {
+      origIt.call(spec, label, async () => {
+        await spec.press(scenario.key);
+        await f();
+      });
+    };
+
+    scenario.spec(spec);
+  }
+}
+
+class AppWrapper extends Component {
+  render() {
+    return (
+      <Tester
+        specs={scenarios.map(x => navigateAndRun(x))}
+        store={store}
+        only={['focus']} >
+        <App />
+      </Tester>
+    );
+  }
+}
+
+AppRegistry.registerComponent(appName, () => AppWrapper);

--- a/test/CavyTester/index.test.js
+++ b/test/CavyTester/index.test.js
@@ -44,7 +44,7 @@ const navigateAndRun = (scenario) => {
   }
 }
 
-class AppWrapper extends Component {
+class TestableApp extends Component {
   render() {
     return (
       <Tester
@@ -57,4 +57,4 @@ class AppWrapper extends Component {
   }
 }
 
-AppRegistry.registerComponent(appName, () => AppWrapper);
+AppRegistry.registerComponent(appName, () => TestableApp);

--- a/test/CavyTester/src/App.js
+++ b/test/CavyTester/src/App.js
@@ -1,53 +1,9 @@
 import React from 'react';
 import { Button } from 'react-native';
 import { createStackNavigator, createAppContainer } from 'react-navigation';
-import { Tester, TestHookStore, useCavy } from 'cavy';
+import { useCavy } from 'cavy';
 
-import * as containsText from './scenarios/containsText';
-import * as containsTextNumerical from './scenarios/containsTextNumerical';
-import * as containsTextUnwrapped from './scenarios/containsTextUnwrapped';
-import * as pressClassComponent from './scenarios/pressClassComponent';
-import * as pressFunctionComponent from './scenarios/pressFunctionComponent';
-import * as exists from './scenarios/exists';
-import * as fillIn from './scenarios/fillIn';
-import * as findComponent from './scenarios/findComponent';
-import * as focus from './scenarios/focus';
-import * as notExists from './scenarios/notExists';
-import * as taggingTest from './scenarios/taggingTest';
-import * as useRef from './scenarios/useRef';
-import * as createRef from './scenarios/createRef';
-import * as callbackRef from './scenarios/callbackRef';
-// Import new scenarios here:
-
-// Add new scenarios here:
-const scenarios = [
-  containsText,
-  containsTextNumerical,
-  containsTextUnwrapped,
-  pressClassComponent,
-  pressFunctionComponent,
-  exists,
-  fillIn,
-  findComponent,
-  focus,
-  notExists,
-  taggingTest,
-  useRef,
-  createRef,
-  callbackRef
-];
-
-// Validate scenarios.
-scenarios.forEach(scenario => {
-  if (!(scenario.key && scenario.label && scenario.Screen && scenario.spec)) {
-    throw Error(
-      'CavyTester: key, label, Screen, and spec must be defined for each scenario'
-    );
-  }
-  if (!/^[a-z0-9]+$/i.exec(scenario.key)) {
-    throw Error('CavyTester: Scenario keys should be alphanumeric');
-  }
-});
+import scenarios from './scenarios';
 
 // Create our HomeScreen which contains a button to each of our test scenarios.
 const HomeScreen = ({ navigation }) => {
@@ -83,42 +39,5 @@ const MainNavigator = createStackNavigator({
 
 const AppContainer = createAppContainer(MainNavigator);
 
-const store = new TestHookStore();
-
-// Map each of our test scenarios, so that each first navigates to the correct
-// scene.
-const navigateAndRun = (scenario) => {
-  return (spec) => {
-    // Override `describe` so that all tests have the 'focus' tag, unless you
-    // specifically pass a different tag in.
-    const origDescribe = spec.describe;
-    spec.describe = (label, f, tag) => {
-      const testTag = tag || 'focus';
-      origDescribe.call(spec, label, f, testTag)
-    }
-
-    // Override `it` so that it first presses into the scene.
-    const origIt = spec.it;
-    spec.it = (label, f) => {
-      origIt.call(spec, label, async () => {
-        await spec.press(scenario.key);
-        await f();
-      });
-    };
-
-    scenario.spec(spec);
-  }
-}
-
 // Wrap our app in the Tester component, containing all our test scenarios.
-const App = () => (
-  <Tester
-    specs={scenarios.map(x => navigateAndRun(x))}
-    store={store}
-    only={['focus']}
-    >
-    <AppContainer />
-  </Tester>
-);
-
-export default App;
+export default App = () => <AppContainer />;

--- a/test/CavyTester/src/scenarios/index.js
+++ b/test/CavyTester/src/scenarios/index.js
@@ -1,0 +1,33 @@
+// Import new scenarios here:
+import * as containsText from './containsText';
+import * as containsTextNumerical from './containsTextNumerical';
+import * as containsTextUnwrapped from './containsTextUnwrapped';
+import * as pressClassComponent from './pressClassComponent';
+import * as pressFunctionComponent from './pressFunctionComponent';
+import * as exists from './exists';
+import * as fillIn from './fillIn';
+import * as findComponent from './findComponent';
+import * as focus from './focus';
+import * as notExists from './notExists';
+import * as taggingTest from './taggingTest';
+import * as useRef from './useRef';
+import * as createRef from './createRef';
+import * as callbackRef from './callbackRef';
+
+// Add new scenarios here:
+export default scenarios = [
+  containsText,
+  containsTextNumerical,
+  containsTextUnwrapped,
+  pressClassComponent,
+  pressFunctionComponent,
+  exists,
+  fillIn,
+  findComponent,
+  focus,
+  notExists,
+  taggingTest,
+  useRef,
+  createRef,
+  callbackRef
+];


### PR DESCRIPTION
**Adds index.test.js to sample app**
- We point to the sample all from the docs, yet up until now it doesn't reflect the suggested way of setting up your app / test app entry files
- This corrects that - the sample app should be the Gold Standard

**Adds index.test.js to Tester app**
- This is the app we run in CI, so it should test as much functionality as possible
- By adding an index.test.js file we now test the file swapping functionality in CI.