### PR TITLE
Cache test data to be sent until WebSocket connection gets established

### DIFF
--- a/src/Reporter.js
+++ b/src/Reporter.js
@@ -4,26 +4,36 @@ export default class Reporter {
   constructor() {
     // Set the Reporter type to realtime.
     this.type = 'realtime';
+    this.cachedTestData = [];
   }
 
   // Internal: Creates a websocket connection to the cavy-cli server.
   onStart() {
     const url = 'ws://127.0.0.1:8082/';
     this.ws = new WebSocket(url);
+    this.ws.onopen = () => {
+      while (testData = this.cachedTestData.shift()) {
+        this.sendData(testData);
+      }
+    };
   }
 
   // Internal: Send a single test result to cavy-cli over the websocket connection.
   send(result) {
-    if (this.websocketReady()) {
-      testData = { event: 'singleResult', data: result };
+    const testData = { event: 'singleResult', data: result };
+    if (this.websocketConnecting()) {
+      this.cachedTestData.push(testData);
+    } else if (this.websocketReady()) {
       this.sendData(testData);
     }
   }
 
   // Internal: Send report to cavy-cli over the websocket connection.
   onFinish(report) {
-    if (this.websocketReady()) {
-      testData = { event: 'testingComplete', data: report };
+    const testData = { event: 'testingComplete', data: report };
+    if (this.websocketConnecting()) {
+      this.cachedTestData.push(testData);
+    } else if (this.websocketReady()) {
       this.sendData(testData);
     } else {
       // If cavy-cli is not running, let people know in a friendly way
@@ -33,6 +43,12 @@ export default class Reporter {
 
       console.log(message);
     }
+  }
+
+  // Private: Determines whether data can not be sent over the websocket yet.
+  websocketConnecting() {
+    // WebSocket.readyState 0 means the web socket connection is CONNECTING.
+    return this.ws.readyState == 0;
   }
 
   // Private: Determines whether data can be sent over the websocket.
@@ -49,9 +65,7 @@ export default class Reporter {
         console.log('Cavy test report successfully sent to cavy-cli');
       }
     } catch (e) {
-      console.group('Error sending test data');
-      console.warn(e.message);
-      console.groupEnd();
+      console.warn(`Error sending test data ${e.message} payload: ${JSON.stringify(testData)}`);
     }
   }
 }


### PR DESCRIPTION
## Problem
If the first test finishes before the socket connection is established, it never gets reported to the CLI server.

## Changed
Added a temporary cache to store results until connection gets established, then send the results to the CLI server.